### PR TITLE
Add --text option to output full report in plain text

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,6 +58,12 @@ With json report:
 cargo llvm-cov --json
 ```
 
+With plain text report (for use in online code coverage services like codecov.io):
+
+```sh
+cargo llvm-cov --text
+```
+
 [source-based-code-coverage]: https://doc.rust-lang.org/nightly/unstable-book/compiler-flags/source-based-code-coverage.html
 
 ## License

--- a/src/main.rs
+++ b/src/main.rs
@@ -37,6 +37,8 @@ struct Args {
     #[structopt(long)]
     json: bool,
     #[structopt(long, conflicts_with = "json")]
+    text: bool,
+    #[structopt(long, conflicts_with_all = &["json", "text"])]
     html: bool,
     #[structopt(long, requires = "html")]
     open: bool,
@@ -197,6 +199,21 @@ fn main() -> Result<()> {
                 &format!("-instr-profile={}", profdata_file.display()),
                 "-format=text",
                 "-summary-only",
+                "-ignore-filename-regex",
+                r".cargo/registry|.rustup/toolchains|test(s)?/",
+                "-Xdemangler=rustfilt",
+            ])
+            .args(files.iter().flat_map(|f| vec!["-object", f]))
+            .run()?;
+    } else if args.text {
+        cargo
+            .args_replace(&[
+                "cov",
+                "--",
+                "show",
+                &format!("-instr-profile={}", profdata_file.display()),
+                "-show-line-counts-or-regions",
+                "-show-instantiations",
                 "-ignore-filename-regex",
                 r".cargo/registry|.rustup/toolchains|test(s)?/",
                 "-Xdemangler=rustfilt",


### PR DESCRIPTION
Add a `--text` option to output the full report in plain text (via `cov show`).

This enables services like codecov.io to consume the report.