### PR TITLE
Require rustfilt only with --html, --open, or --text flag

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,14 @@ Note: In this file, do not use the hard wrap in the middle of a sentence for com
 
 ## [Unreleased]
 
+- If you don't use the `--html`, `--open`, or `--text` flag, cargo-llvm-cov no longer requires rustfilt.
+
+- [Add `--color` option.](https://github.com/taiki-e/cargo-llvm-cov/pull/15)
+
+- [Add `--no-fail-fast`, `--frozen`, and `--locked` option.](https://github.com/taiki-e/cargo-llvm-cov/pull/16)
+
+- Improve diagnostics when the required tools are not installed.
+
 ## [0.1.0-alpha.3] - 2021-06-04
 
 - [cargo-llvm-cov no longer requires cargo-binutils.](https://github.com/taiki-e/cargo-llvm-cov/pull/11)

--- a/README.md
+++ b/README.md
@@ -10,23 +10,36 @@ A wrapper for source based code coverage ([-Zinstrument-coverage][instrument-cov
 
 ## Installation
 
-cargo-llvm-cov currently requires llvm-tools-preview and [rustfilt](https://github.com/luser/rustfilt).
+### Prerequisites
+
+cargo-llvm-cov requires nightly
+toolchain and llvm-tools-preview:
 
 ```sh
-cargo install cargo-llvm-cov --version 0.1.0-alpha.3
-
-cargo install rustfilt
-
 rustup component add llvm-tools-preview
 ```
 
-Alternatively, download compiled binaries from [GitHub Releases](https://github.com/taiki-e/cargo-llvm-cov/releases).
+If you use the `--html`, `--open`, or `--text` flag, [rustfilt](https://github.com/luser/rustfilt) is also required:
+
+```sh
+cargo install rustfilt
+```
+
+### From source
+
+```sh
+cargo install cargo-llvm-cov --version 0.1.0-alpha.3
+```
 
 cargo-llvm-cov relies on unstable compiler flags so it requires a nightly
 toolchain to be installed, though does not require nightly to be the default
 toolchain or the one with which cargo-llvm-cov itself is executed. If the default
 toolchain is one other than nightly, running `cargo llvm-cov` will find and use
 nightly anyway.
+
+### From binaries
+
+You can download prebuilt binaries from the [Release page](https://github.com/taiki-e/cargo-llvm-cov/releases).
 
 ## Usage
 
@@ -185,8 +198,6 @@ jobs:
         run: rustup toolchain install nightly --component llvm-tools-preview
       - name: Install cargo-llvm-cov
         run: curl -LsSf https://github.com/taiki-e/cargo-llvm-cov/releases/download/v0.1.0-alpha.3/cargo-llvm-cov-x86_64-unknown-linux-gnu.tar.gz | tar xzf - -C ~/.cargo/bin
-      - name: Install rustfilt
-        run: cargo install rustfilt
       - name: Generate code coverage
         run: cargo llvm-cov --all-features --workspace --lcov > lcov.info
       - name: Upload coverage to Codecov

--- a/src/process.rs
+++ b/src/process.rs
@@ -20,8 +20,6 @@ pub(crate) struct ProcessBuilder {
     program: OsString,
     /// A list of arguments to pass to the program.
     args: Vec<OsString>,
-    /// The length of arguments that is not replaced by `args_replace`.
-    base_args: usize,
     /// The environment variables in the expression's environment.
     env: BTreeMap<String, Option<OsString>>,
     /// The working directory where the expression will execute.
@@ -36,18 +34,10 @@ impl ProcessBuilder {
         Self {
             program: program.into(),
             args: Vec::new(),
-            base_args: 0,
             env: BTreeMap::new(),
             dir: None,
             stdout_to_stderr: false,
         }
-    }
-
-    /// (chainable) Adds `arg` to the args list.
-    pub(crate) fn base_arg(&mut self, arg: impl Into<OsString>) -> &mut Self {
-        self.args.insert(self.base_args, arg.into());
-        self.base_args += 1;
-        self
     }
 
     /// (chainable) Adds `arg` to the args list.
@@ -58,16 +48,6 @@ impl ProcessBuilder {
 
     /// (chainable) Adds multiple `args` to the args list.
     pub(crate) fn args(&mut self, args: impl IntoIterator<Item = impl AsRef<OsStr>>) -> &mut Self {
-        self.args.extend(args.into_iter().map(|t| t.as_ref().to_os_string()));
-        self
-    }
-
-    /// (chainable) Replaces the args list with the given `args`.
-    pub(crate) fn args_replace(
-        &mut self,
-        args: impl IntoIterator<Item = impl AsRef<OsStr>>,
-    ) -> &mut Self {
-        self.args.truncate(self.base_args);
         self.args.extend(args.into_iter().map(|t| t.as_ref().to_os_string()));
         self
     }


### PR DESCRIPTION
- If you don't use the `--html`, `--open`, or `--text` flag, cargo-llvm-cov no longer requires rustfilt.
- Improve diagnostics when the required tools are not installed.