### PR TITLE
Various refactoring

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,11 +12,19 @@ Note: In this file, do not use the hard wrap in the middle of a sentence for com
 
 - [If you don't use the `--html`, `--open`, or `--text` flag, cargo-llvm-cov no longer requires rustfilt.](https://github.com/taiki-e/cargo-llvm-cov/pull/17)
 
-- [Add `--output-path` option.](https://github.com/taiki-e/cargo-llvm-cov/pull/18)
+- [Add `--output-path` option to specify a file to write coverage data into.](https://github.com/taiki-e/cargo-llvm-cov/pull/18)
+
+- Add `--ignore-filename-regex` option to skip specified source code files from coverage report.
 
 - [Add `--color` option.](https://github.com/taiki-e/cargo-llvm-cov/pull/15)
 
 - [Add `--no-fail-fast`, `--frozen`, and `--locked` option.](https://github.com/taiki-e/cargo-llvm-cov/pull/16)
+
+- Add `--verbose` flag.
+
+- Fix an issue where git dependencies were displayed in the coverage report.
+
+- Fix several bugs.
 
 - [Improve diagnostics when the required tools are not installed.](https://github.com/taiki-e/cargo-llvm-cov/pull/17)
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,13 +23,18 @@ anyhow = "1.0.34"
 camino = "1"
 cargo_metadata = "0.13"
 duct = "0.13.1"
-fs-err = "2.5"
 glob = "0.3"
 is_executable = "1"
 open = "1.2"
 serde = { version = "1.0.103", features = ["derive"] }
 serde_json = "1"
+shell-escape = "0.1.5"
 structopt = "0.3"
+tracing = { version = "0.1.21", default-features = false, features = ["std"] }
+tracing-subscriber = { version = "0.2.16", default-features = false, features = ["ansi", "env-filter"] }
+
+# This is needed for -Zminimal-versions.
+lazy_static = "1.4"
 
 [dev-dependencies]
 once_cell = "1"

--- a/README.md
+++ b/README.md
@@ -98,6 +98,9 @@ OPTIONS:
             Specify a directory to write coverage reports into (default to `target/llvm-cov`).
 
             This flag can only be used together with --text, --html, or --open. See also --output-path.
+        --ignore-filename-regex <PATTERN>
+            Skip source code files with file paths that match the given regular expression
+
         --doctests
             Including doc tests (unstable)
 
@@ -127,6 +130,9 @@ OPTIONS:
 
         --manifest-path <PATH>
             Path to Cargo.toml
+
+    -v, --verbose
+            Use verbose output (-vv very verbose/build.rs output)
 
         --color <WHEN>
             Coloring: auto, always, never

--- a/src/fs.rs
+++ b/src/fs.rs
@@ -1,50 +1,95 @@
-#![allow(dead_code, unused_imports)]
-
 use std::{io, path::Path};
 
-pub(crate) use fs_err::*;
+use anyhow::{Context as _, Result};
 
 /// Creates a new, empty directory **if not exists**.
 /// This is a wrapper for [`std::fs::create_dir`].
-pub(crate) fn create_dir(path: impl AsRef<Path>) -> io::Result<()> {
-    match fs_err::create_dir(path) {
-        Err(e) if e.kind() == io::ErrorKind::AlreadyExists => Ok(()),
-        res => res,
+#[track_caller]
+pub(crate) fn create_dir(path: impl AsRef<Path>) -> Result<()> {
+    let path = path.as_ref();
+    match std::fs::create_dir(path) {
+        Err(e) if e.kind() == io::ErrorKind::AlreadyExists => {
+            trace!(track_caller: res = ?Ok::<_, ()>(e), ?path, "create_dir");
+            Ok(())
+        }
+        res => {
+            trace!(track_caller: ?res, ?path, "create_dir");
+            res.with_context(|| format!("failed to create directory `{}`", path.display()))
+        }
     }
 }
 
 /// Recursively create a directory **if not exists**.
 /// This is a wrapper for [`std::fs::create_dir_all`].
-pub(crate) fn create_dir_all(path: impl AsRef<Path>) -> io::Result<()> {
-    match fs_err::create_dir_all(path) {
-        Err(e) if e.kind() == io::ErrorKind::AlreadyExists => Ok(()),
-        res => res,
+#[track_caller]
+pub(crate) fn create_dir_all(path: impl AsRef<Path>) -> Result<()> {
+    let path = path.as_ref();
+    match std::fs::create_dir_all(path) {
+        Err(e) if e.kind() == io::ErrorKind::AlreadyExists => {
+            trace!(track_caller: res = ?Ok::<_, ()>(e), ?path, "create_dir_all");
+            Ok(())
+        }
+        res => {
+            trace!(track_caller: ?res, ?path, "create_dir_all");
+            res.with_context(|| format!("failed to create directory `{}`", path.display()))
+        }
     }
 }
 
 /// Removes a file from the filesystem **if exists**.
 /// This is a wrapper for [`std::fs::remove_file`].
-pub(crate) fn remove_file(path: impl AsRef<Path>) -> io::Result<()> {
-    match fs_err::remove_file(path) {
-        Err(e) if e.kind() == io::ErrorKind::NotFound => Ok(()),
-        res => res,
-    }
-}
-
-/// Removes an empty directory **if exists**.
-/// This is a wrapper for [`std::fs::remove_dir`].
-pub(crate) fn remove_dir(path: impl AsRef<Path>) -> io::Result<()> {
-    match fs_err::remove_dir(path) {
-        Err(e) if e.kind() == io::ErrorKind::NotFound => Ok(()),
-        res => res,
+#[track_caller]
+pub(crate) fn remove_file(path: impl AsRef<Path>) -> Result<()> {
+    let path = path.as_ref();
+    match std::fs::remove_file(path) {
+        Err(e) if e.kind() == io::ErrorKind::NotFound => {
+            trace!(track_caller: res = ?Ok::<_, ()>(e), ?path, "remove_file");
+            Ok(())
+        }
+        res => {
+            trace!(track_caller: ?res, ?path, "remove_file");
+            res.with_context(|| format!("failed to remove file `{}`", path.display()))
+        }
     }
 }
 
 /// Removes a directory at this path **if exists**.
 /// This is a wrapper for [`std::fs::remove_dir_all`].
-pub(crate) fn remove_dir_all(path: impl AsRef<Path>) -> io::Result<()> {
-    match fs_err::remove_dir_all(path) {
-        Err(e) if e.kind() == io::ErrorKind::NotFound => Ok(()),
-        res => res,
+#[track_caller]
+pub(crate) fn remove_dir_all(path: impl AsRef<Path>) -> Result<()> {
+    let path = path.as_ref();
+    match std::fs::remove_dir_all(path) {
+        Err(e) if e.kind() == io::ErrorKind::NotFound => {
+            trace!(track_caller: res = ?Ok::<_, ()>(e), ?path, "remove_dir_all");
+            Ok(())
+        }
+        res => {
+            trace!(track_caller: ?res, ?path, "remove_dir_all");
+            res.with_context(|| format!("failed to remove directory `{}`", path.display()))
+        }
     }
+}
+
+/// Copies the contents of one file to another.
+/// This is a wrapper for [`std::fs::copy`].
+#[cfg(test)]
+#[track_caller]
+pub(crate) fn copy(from: impl AsRef<Path>, to: impl AsRef<Path>) -> Result<u64> {
+    let from = from.as_ref();
+    let to = to.as_ref();
+    let res = std::fs::copy(from, to);
+    trace!(track_caller: ?res, ?from, ?to, "copy");
+    res.with_context(|| {
+        format!("failed to copy file from `{}` to `{}`", from.display(), to.display())
+    })
+}
+
+/// Write a slice as the entire contents of a file.
+/// This is a wrapper for [`std::fs::write`].
+#[track_caller]
+pub(crate) fn write(path: impl AsRef<Path>, contents: impl AsRef<[u8]>) -> Result<()> {
+    let path = path.as_ref();
+    let res = std::fs::write(path, contents.as_ref());
+    trace!(track_caller: ?res, ?path, "write");
+    res.with_context(|| format!("failed to write to file `{}`", path.display()))
 }

--- a/src/tests/auxiliary.rs
+++ b/src/tests/auxiliary.rs
@@ -5,13 +5,11 @@ use std::{
 
 use anyhow::Result;
 use camino::{Utf8Path, Utf8PathBuf};
-use duct::cmd;
 use once_cell::sync::Lazy;
-use structopt::StructOpt;
 use tempfile::{Builder, TempDir};
 use walkdir::WalkDir;
 
-use crate::{fs, Opts};
+use crate::fs;
 
 static FIXTURES_PATH: Lazy<Utf8PathBuf> =
     Lazy::new(|| Utf8Path::new(env!("CARGO_MANIFEST_DIR")).join("tests/fixtures"));
@@ -40,10 +38,9 @@ pub(crate) fn cargo_llvm_cov<'a>(
         output_path.as_str(),
     ];
     v.extend(args.as_ref().iter());
-    let opts = Opts::from_iter_safe(v)?;
-    crate::run(opts)?;
+    crate::run(v)?;
     if env::var_os("CI").is_some() {
-        cmd!("git", "--no-pager", "diff", "--exit-code", output_path).run()?;
+        process!("git", "--no-pager", "diff", "--exit-code", output_path).run()?;
     }
     Ok(())
 }

--- a/src/tests/mod.rs
+++ b/src/tests/mod.rs
@@ -20,3 +20,7 @@ fn test() {
     set("real1", "workspace_root");
     set("virtual1", "workspace_root");
 }
+
+// TODO:
+// - add tests for non-crates.io dependencies
+// - add tests for --exclude

--- a/src/trace.rs
+++ b/src/trace.rs
@@ -1,0 +1,54 @@
+use std::{env, io};
+
+use tracing::Level;
+
+macro_rules! trace {
+    (track_caller: $($tt:tt)*) => {
+        tracing::trace!(
+            location = %{
+                let location = std::panic::Location::caller();
+                format_args!("{}:{}:{}", location.file(), location.line(), location.column())
+            },
+            $($tt)*
+        )
+    };
+    ($($tt:tt)*) => {
+        tracing::trace!(
+            location = %format_args!("{}:{}:{}", file!(), line!(), column!()),
+            $($tt)*
+        )
+    };
+}
+
+macro_rules! debug {
+    (track_caller: $($tt:tt)*) => {
+        tracing::debug!(
+            location = %{
+                let location = std::panic::Location::caller();
+                format_args!("{}:{}:{}", location.file(), location.line(), location.column())
+            },
+            $($tt)*
+        )
+    };
+    ($($tt:tt)*) => {
+        tracing::debug!(
+            location = %format_args!("{}:{}:{}", file!(), line!(), column!()),
+            $($tt)*
+        )
+    };
+}
+
+pub(crate) fn init() {
+    let rust_log = env::var_os("RUST_LOG");
+    if rust_log.is_none() {
+        env::set_var(
+            "RUST_LOG",
+            format!("{}={}", env!("CARGO_BIN_NAME").replace('-', "_"), Level::INFO),
+        );
+    }
+    tracing_subscriber::fmt()
+        .with_env_filter(tracing_subscriber::EnvFilter::from_default_env())
+        .with_writer(io::stderr)
+        .init();
+    debug!(RUST_LOG = ?rust_log);
+}


### PR DESCRIPTION
- Add `--ignore-filename-regex` option to skip specified source code files from coverage report.
- Add `--verbose` flag.
- Fix an issue where git dependencies were displayed in the coverage report.
- Fix several bugs.