### PR TITLE
Change output directory of --html/--open to target/llvm-cov/html

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,8 @@ Note: In this file, do not use the hard wrap in the middle of a sentence for com
 
 - [Fix bug in `--exclude` and `--package` options](https://github.com/taiki-e/cargo-llvm-cov/pull/56)
 
+- Change output directory of `--html` and `--open` options from `target/llvm-cov` to `target/llvm-cov/html`.
+
 - `--html` and `--open` options no longer outputs a summary at the same time.
 
 - [Recognize rustflags and rustdocflags set by config file.](https://github.com/taiki-e/cargo-llvm-cov/pull/52)

--- a/README.md
+++ b/README.md
@@ -107,7 +107,7 @@ OPTIONS:
 
         --html
             Generate coverage reports in "html" format. If --output-dir is not specified, the report
-            will be generated in `target/llvm-cov` directory.
+            will be generated in `target/llvm-cov/html` directory.
 
             This internally calls `llvm-cov show -format=html`. See
             <https://llvm.org/docs/CommandGuide/llvm-cov.html#llvm-cov-show> for more.
@@ -205,11 +205,11 @@ By default, only the summary is printed to stdout.
 cargo llvm-cov
 ```
 
-With html report (the report will be generated to `target/llvm-cov` directory):
+With html report (the report will be generated to `target/llvm-cov/html` directory):
 
 ```sh
 cargo llvm-cov --html
-open target/llvm-cov/index.html
+open target/llvm-cov/html/index.html
 ```
 
 or

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -67,7 +67,7 @@ pub(crate) struct Args {
     pub(crate) text: bool,
     /// Generate coverage reports in "html" format.
     ////
-    /// If --output-dir is not specified, the report will be generated in `target/llvm-cov` directory.
+    /// If --output-dir is not specified, the report will be generated in `target/llvm-cov/html` directory.
     ///
     /// This internally calls `llvm-cov show -format=html`.
     /// See <https://llvm.org/docs/CommandGuide/llvm-cov.html#llvm-cov-show> for more.

--- a/src/context.rs
+++ b/src/context.rs
@@ -54,7 +54,7 @@ impl Context {
         let config = cargo::config(&cargo, &metadata.workspace_root)?;
         config.merge_to(&mut args, &mut env);
 
-        term::set_coloring(args.color);
+        term::set_coloring(&mut args.color);
 
         if let Some(v) = env::var_os("LLVM_PROFILE_FILE") {
             warn!("environment variable LLVM_PROFILE_FILE={:?} will be ignored", v);

--- a/src/context.rs
+++ b/src/context.rs
@@ -69,6 +69,9 @@ impl Context {
         if args.disable_default_ignore_filename_regex {
             warn!("--disable-default-ignore-filename-regex option is unstable");
         }
+        if args.hide_instantiations {
+            warn!("--hide-instantiations option is unstable");
+        }
         if args.doctests {
             warn!("--doctests option is unstable");
         }

--- a/src/main.rs
+++ b/src/main.rs
@@ -70,8 +70,12 @@ fn try_main() -> Result<()> {
 
 fn clean_partial(cx: &Context) -> Result<()> {
     if let Some(output_dir) = &cx.output_dir {
-        fs::remove_dir_all(output_dir.join("html"))?;
-        fs::remove_dir_all(output_dir.join("text"))?;
+        if cx.html {
+            fs::remove_dir_all(output_dir.join("html"))?;
+        }
+        if cx.text {
+            fs::remove_dir_all(output_dir.join("text"))?;
+        }
     }
 
     for path in glob::glob(cx.target_dir.join("*.profraw").as_str())?.filter_map(Result::ok) {

--- a/src/term.rs
+++ b/src/term.rs
@@ -13,12 +13,13 @@ const AUTO: u8 = Coloring::Auto as _;
 const ALWAYS: u8 = Coloring::Always as _;
 const NEVER: u8 = Coloring::Never as _;
 
-pub(crate) fn set_coloring(coloring: Option<Coloring>) {
-    let mut coloring = coloring.unwrap_or(Coloring::Auto);
-    if coloring == Coloring::Auto && !atty::is(atty::Stream::Stderr) {
-        coloring = Coloring::Never;
+pub(crate) fn set_coloring(coloring: &mut Option<Coloring>) {
+    let mut color = coloring.unwrap_or(Coloring::Auto);
+    if color == Coloring::Auto && !atty::is(atty::Stream::Stderr) {
+        *coloring = Some(Coloring::Never);
+        color = Coloring::Never;
     }
-    COLORING.store(coloring as _, Relaxed);
+    COLORING.store(color as _, Relaxed);
 }
 
 fn coloring() -> ColorChoice {

--- a/tests/long-help.txt
+++ b/tests/long-help.txt
@@ -44,7 +44,7 @@ OPTIONS:
 
         --html
             Generate coverage reports in "html" format. If --output-dir is not specified, the report
-            will be generated in `target/llvm-cov` directory.
+            will be generated in `target/llvm-cov/html` directory.
 
             This internally calls `llvm-cov show -format=html`. See
             <https://llvm.org/docs/CommandGuide/llvm-cov.html#llvm-cov-show> for more.

--- a/tests/short-help.txt
+++ b/tests/short-help.txt
@@ -28,7 +28,7 @@ OPTIONS:
 
         --html
             Generate coverage reports in "html" format. If --output-dir is not specified, the report
-            will be generated in `target/llvm-cov` directory
+            will be generated in `target/llvm-cov/html` directory
 
         --open
             Generate coverage reports in "html" format and open them in a browser after the


### PR DESCRIPTION
Change output directory of `--html` and `--open` options from `target/llvm-cov` to `target/llvm-cov/html`.

Prepare for #60.