### PR TITLE
Release 0.1.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,15 @@ Note: In this file, do not use the hard wrap in the middle of a sentence for com
 
 ## [Unreleased]
 
-- You can now merge the coverages generated under different test conditions by using `--no-report` and `--no-run`.
+## [0.1.0] - 2021-08-15
+
+- [Update clap to fix build error.](https://github.com/taiki-e/cargo-llvm-cov/pull/59)
+
+- [Support latest version of trybuild.](https://github.com/taiki-e/cargo-llvm-cov/pull/54)
+
+- [Change output directory of `--html` and `--open` options from `target/llvm-cov` to `target/llvm-cov/html`.](https://github.com/taiki-e/cargo-llvm-cov/pull/62)
+
+- [You can now merge the coverages generated under different test conditions by using `--no-report` and `--no-run`.](https://github.com/taiki-e/cargo-llvm-cov/pull/55)
 
   ```sh
   cargo clean
@@ -19,13 +27,18 @@ Note: In this file, do not use the hard wrap in the middle of a sentence for com
   cargo llvm-cov --no-run --lcov
   ```
 
+- [Add environment variables to pass additional flags to llvm-cov/llvm-profdata.](https://github.com/taiki-e/cargo-llvm-cov/pull/58)
+
+  - `CARGO_LLVM_COV_FLAGS` to pass additional flags to llvm-cov. (value: space-separated list)
+  - `CARGO_LLVM_PROFDATA_FLAGS` to pass additional flags to llvm-profdata. (value: space-separated list)
+
 - [Fix "Failed to load coverage" error when together used with trybuild.](https://github.com/taiki-e/cargo-llvm-cov/pull/49)
 
 - [Fix bug in `--exclude` and `--package` options](https://github.com/taiki-e/cargo-llvm-cov/pull/56)
 
-- Change output directory of `--html` and `--open` options from `target/llvm-cov` to `target/llvm-cov/html`.
+- [Fix bug in color-detection when both `--text` and `--output-dir` used.](https://github.com/taiki-e/cargo-llvm-cov/pull/62)
 
-- `--html` and `--open` options no longer outputs a summary at the same time.
+- [`--html` and `--open` options no longer outputs a summary at the same time.](https://github.com/taiki-e/cargo-llvm-cov/pull/61)
 
 - [Recognize rustflags and rustdocflags set by config file.](https://github.com/taiki-e/cargo-llvm-cov/pull/52)
 
@@ -99,7 +112,8 @@ Note: In this file, do not use the hard wrap in the middle of a sentence for com
 
 Initial release
 
-[Unreleased]: https://github.com/taiki-e/cargo-llvm-cov/compare/v0.1.0-alpha.5...HEAD
+[Unreleased]: https://github.com/taiki-e/cargo-llvm-cov/compare/v0.1.0...HEAD
+[0.1.0]: https://github.com/taiki-e/cargo-llvm-cov/compare/v0.1.0-alpha.5...v0.1.0
 [0.1.0-alpha.5]: https://github.com/taiki-e/cargo-llvm-cov/compare/v0.1.0-alpha.4...v0.1.0-alpha.5
 [0.1.0-alpha.4]: https://github.com/taiki-e/cargo-llvm-cov/compare/v0.1.0-alpha.3...v0.1.0-alpha.4
 [0.1.0-alpha.3]: https://github.com/taiki-e/cargo-llvm-cov/compare/v0.1.0-alpha.2...v0.1.0-alpha.3

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cargo-llvm-cov"
-version = "0.1.0-alpha.5"
+version = "0.1.0"
 authors = ["Taiki Endo <te316e89@gmail.com>"]
 edition = "2018"
 license = "Apache-2.0 OR MIT"
@@ -9,7 +9,7 @@ keywords = ["cargo", "coverage", "subcommand", "testing"]
 categories = ["command-line-utilities", "development-tools", "development-tools::cargo-plugins", "development-tools::testing"]
 exclude = ["/.*", "/tools"]
 description = """
-Cargo subcommand for LLVM source-based code coverage (-Z instrument-coverage).
+Cargo subcommand to easily use LLVM source-based code coverage (-Z instrument-coverage).
 """
 
 [package.metadata.docs.rs]

--- a/README.md
+++ b/README.md
@@ -5,7 +5,16 @@
 [![rustc](https://img.shields.io/badge/rustc-stable-blue?style=flat-square&logo=rust)](https://www.rust-lang.org)
 [![build status](https://img.shields.io/github/workflow/status/taiki-e/cargo-llvm-cov/CI/main?style=flat-square&logo=github)](https://github.com/taiki-e/cargo-llvm-cov/actions)
 
-Cargo subcommand for LLVM source-based code coverage ([-Z instrument-coverage][instrument-coverage], [rust-lang/rust#79121]).
+Cargo subcommand to easily use LLVM source-based code coverage.
+
+This is a wrapper around rustc [`-Z instrument-coverage`][instrument-coverage] and provides:
+
+- Generate very precise coverage data. (line coverage and region coverage)
+- Support for proc-macro, including coverage of UI tests.
+- Support for doc tests. (this is currently optional, see [#2] for more)
+- Command-line interface compatible with `cargo test`.
+
+**Table of Contents:**
 
 - [Installation](#installation)
 - [Usage](#usage)
@@ -29,7 +38,7 @@ rustup component add llvm-tools-preview --toolchain nightly
 ### From source
 
 ```sh
-cargo install cargo-llvm-cov --version 0.1.0-alpha.5
+cargo install cargo-llvm-cov
 ```
 
 cargo-llvm-cov relies on unstable compiler flags so it requires a nightly
@@ -63,7 +72,7 @@ brew install taiki-e/tap/cargo-llvm-cov
 $ cargo llvm-cov --help
 cargo-llvm-cov
 
-Cargo subcommand for LLVM source-based code coverage (-Z instrument-coverage).
+Cargo subcommand to easily use LLVM source-based code coverage (-Z instrument-coverage).
 
 Use -h for short descriptions and --help for more details.
 
@@ -199,7 +208,7 @@ OPTIONS:
 
 </details>
 
-By default, only the summary is printed to stdout.
+By default, run tests, and print the coverage summary to stdout.
 
 ```sh
 cargo llvm-cov
@@ -262,7 +271,7 @@ jobs:
       - name: Install Rust
         run: rustup toolchain install nightly --component llvm-tools-preview
       - name: Install cargo-llvm-cov
-        run: curl -LsSf https://github.com/taiki-e/cargo-llvm-cov/releases/download/v0.1.0-alpha.5/cargo-llvm-cov-x86_64-unknown-linux-gnu.tar.gz | tar xzf - -C ~/.cargo/bin
+        run: curl -LsSf https://github.com/taiki-e/cargo-llvm-cov/releases/latest/download/cargo-llvm-cov-x86_64-unknown-linux-gnu.tar.gz | tar xzf - -C ~/.cargo/bin
       - name: Generate code coverage
         run: cargo llvm-cov --all-features --workspace --lcov --output-path lcov.info
       - name: Upload coverage to Codecov
@@ -291,7 +300,6 @@ See also [the code-coverage-related issues reported in rust-lang/rust](https://g
 [#26]: https://github.com/taiki-e/cargo-llvm-cov/issues/26
 [codecov]: https://codecov.io
 [instrument-coverage]: https://doc.rust-lang.org/nightly/unstable-book/compiler-flags/instrument-coverage.html
-[rust-lang/rust#79121]: https://github.com/rust-lang/rust/issues/79121
 [rust-lang/rust#79417]: https://github.com/rust-lang/rust/issues/79417
 [rust-lang/rust#79649]: https://github.com/rust-lang/rust/issues/79649
 [rust-lang/rust#86177]: https://github.com/rust-lang/rust/issues/86177

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -8,7 +8,8 @@ pub(crate) fn from_args() -> Result<Args> {
     Ok(args)
 }
 
-const ABOUT: &str = "Cargo subcommand for LLVM source-based code coverage (-Z instrument-coverage).
+const ABOUT: &str =
+    "Cargo subcommand to easily use LLVM source-based code coverage (-Z instrument-coverage).
 
 Use -h for short descriptions and --help for more details.";
 

--- a/tests/long-help.txt
+++ b/tests/long-help.txt
@@ -1,6 +1,6 @@
 cargo-llvm-cov
 
-Cargo subcommand for LLVM source-based code coverage (-Z instrument-coverage).
+Cargo subcommand to easily use LLVM source-based code coverage (-Z instrument-coverage).
 
 Use -h for short descriptions and --help for more details.
 

--- a/tests/short-help.txt
+++ b/tests/short-help.txt
@@ -1,6 +1,6 @@
 cargo-llvm-cov
 
-Cargo subcommand for LLVM source-based code coverage (-Z instrument-coverage).
+Cargo subcommand to easily use LLVM source-based code coverage (-Z instrument-coverage).
 
 Use -h for short descriptions and --help for more details.
 


### PR DESCRIPTION
Closes #35 

Changes:

- [Update clap to fix build error.](https://github.com/taiki-e/cargo-llvm-cov/pull/59)

- [Support latest version of trybuild.](https://github.com/taiki-e/cargo-llvm-cov/pull/54)

- [Change output directory of `--html` and `--open` options from `target/llvm-cov` to `target/llvm-cov/html`.](https://github.com/taiki-e/cargo-llvm-cov/pull/62)

- [You can now merge the coverages generated under different test conditions by using `--no-report` and `--no-run`.](https://github.com/taiki-e/cargo-llvm-cov/pull/55)

  ```sh
  cargo clean
  cargo llvm-cov --no-report --features a
  cargo llvm-cov --no-report --features b
  cargo llvm-cov --no-run --lcov
  ```

- [Add environment variables to pass additional flags to llvm-cov/llvm-profdata.](https://github.com/taiki-e/cargo-llvm-cov/pull/58)

  - `CARGO_LLVM_COV_FLAGS` to pass additional flags to llvm-cov. (value: space-separated list)
  - `CARGO_LLVM_PROFDATA_FLAGS` to pass additional flags to llvm-profdata. (value: space-separated list)

- [Fix "Failed to load coverage" error when together used with trybuild.](https://github.com/taiki-e/cargo-llvm-cov/pull/49)

- [Fix bug in `--exclude` and `--package` options](https://github.com/taiki-e/cargo-llvm-cov/pull/56)

- [Fix bug in color-detection when both `--text` and `--output-dir` used.](https://github.com/taiki-e/cargo-llvm-cov/pull/62)

- [`--html` and `--open` options no longer outputs a summary at the same time.](https://github.com/taiki-e/cargo-llvm-cov/pull/61)

- [Recognize rustflags and rustdocflags set by config file.](https://github.com/taiki-e/cargo-llvm-cov/pull/52)

- Diagnostic improvements.