### PR TITLE
Add clean subcommand

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,8 @@ Note: In this file, do not use the hard wrap in the middle of a sentence for com
 
 - [Add `--quiet`, `--doc`, and `--jobs` options.](https://github.com/taiki-e/cargo-llvm-cov/pull/70)
 
+- [Add `cargo llvm-cov clean` subcommand.](https://github.com/taiki-e/cargo-llvm-cov/pull/73)
+
 ## [0.1.1] - 2021-08-25
 
 - [Add `--lib`, `--bin`, `--bins`, `--example`, `--examples`, `--test`, `--tests`, `--bench`, `--benches`, `--all-targets`, `--profile`, and `--offline` options.](https://github.com/taiki-e/cargo-llvm-cov/pull/67)

--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ Cargo subcommand to easily use LLVM source-based code coverage (-Z instrument-co
 Use -h for short descriptions and --help for more details.
 
 USAGE:
-    cargo llvm-cov [OPTIONS] [-- <ARGS>...]
+    cargo llvm-cov [OPTIONS] [-- <ARGS>...] [SUBCOMMAND]
 
 ARGS:
     <ARGS>...
@@ -219,6 +219,12 @@ OPTIONS:
 
     -Z <FLAG>...
             Unstable (nightly-only) flags to Cargo
+
+SUBCOMMANDS:
+    clean
+            Remove artifacts that cargo-llvm-cov has generated in the past
+    help
+            Print this message or the help of the given subcommand(s)
 ```
 <!-- readme-long-help:end -->
 

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -15,6 +15,7 @@ const MAX_TERM_WIDTH: usize = 100;
     version,
     max_term_width(MAX_TERM_WIDTH),
     setting(AppSettings::DeriveDisplayOrder),
+    setting(AppSettings::DisableVersionForSubcommands),
     setting(AppSettings::StrictUtf8),
     setting(AppSettings::UnifiedHelpMessage)
 )]
@@ -29,6 +30,7 @@ pub(crate) enum Opts {
     about(ABOUT),
     max_term_width(MAX_TERM_WIDTH),
     setting(AppSettings::DeriveDisplayOrder),
+    setting(AppSettings::DisableVersionForSubcommands),
     setting(AppSettings::StrictUtf8),
     setting(AppSettings::UnifiedHelpMessage)
 )]
@@ -288,8 +290,39 @@ impl Args {
 
 #[derive(Debug, Clap)]
 pub(crate) enum Subcommand {
+    /// Remove artifacts that cargo-llvm-cov has generated in the past
+    #[clap(
+        bin_name = "cargo llvm-cov clean",
+        max_term_width = MAX_TERM_WIDTH,
+        setting = AppSettings::DeriveDisplayOrder,
+        setting = AppSettings::StrictUtf8,
+        setting = AppSettings::UnifiedHelpMessage,
+    )]
+    Clean {
+        // TODO: Currently, we are using a subdirectory of the target directory as
+        //       the actual target directory. What effect should this option have
+        //       on its behavior?
+        // /// Directory for all generated artifacts
+        // #[clap(long, value_name = "DIRECTORY")]
+        // target_dir: Option<Utf8PathBuf>,
+        /// Path to Cargo.toml
+        #[clap(long, value_name = "PATH")]
+        manifest_path: Option<Utf8PathBuf>,
+        // TODO
+        // /// Use verbose output
+        // ///
+        // /// Use -vv (-vvv) to propagate verbosity to cargo.
+        // #[clap(short, long, parse(from_occurrences))]
+        // verbose: u8,
+        /// Coloring
+        // This flag will be propagated to both cargo and llvm-cov.
+        #[clap(long, arg_enum, value_name = "WHEN")]
+        color: Option<Coloring>,
+    },
+
     // internal (unstable)
     #[clap(
+        bin_name = "cargo llvm-cov demangle",
         max_term_width = MAX_TERM_WIDTH,
         setting = AppSettings::DeriveDisplayOrder,
         setting = AppSettings::StrictUtf8,

--- a/src/config.rs
+++ b/src/config.rs
@@ -1,0 +1,166 @@
+// Refs:
+// - https://doc.rust-lang.org/nightly/cargo/reference/config.html
+// - https://doc.rust-lang.org/nightly/cargo/reference/unstable.html#cargo-config
+// - https://github.com/rust-lang/cargo/issues/9301
+
+use std::ffi::OsStr;
+
+use anyhow::{format_err, Result};
+use camino::Utf8Path;
+use serde::Deserialize;
+
+use crate::{
+    cargo::Cargo,
+    cli::{Args, Coloring},
+    env::{self, Env},
+};
+
+#[derive(Debug, Default, Deserialize)]
+pub(crate) struct Config {
+    #[serde(default)]
+    pub(crate) build: Build,
+    #[serde(default)]
+    pub(crate) doc: Doc,
+    #[serde(default)]
+    pub(crate) term: Term,
+}
+
+impl Config {
+    pub(crate) fn new(cargo: &Cargo, workspace_root: &Utf8Path) -> Result<Config> {
+        let mut config = match cargo
+            .nightly_process()
+            .args(&["-Z", "unstable-options", "config", "get", "--format", "json"])
+            .dir(workspace_root)
+            .stderr_capture()
+            .read()
+        {
+            Ok(s) => serde_json::from_str(&s)?,
+            Err(e) => {
+                // Allow error from cargo-config as it is an unstable feature.
+                warn!("{:#}", e);
+                Config::default()
+            }
+        };
+        config.apply_env()?;
+        Ok(config)
+    }
+
+    // Apply configuration environment variables
+    fn apply_env(&mut self) -> Result<()> {
+        // Environment variables are prefer over config values.
+        // https://doc.rust-lang.org/nightly/cargo/reference/config.html#environment-variables
+        if let Some(rustc) = env::ver("CARGO_BUILD_RUSTC")? {
+            self.build.rustc = Some(rustc);
+        }
+        if let Some(rustflags) = env::ver("CARGO_BUILD_RUSTFLAGS")? {
+            self.build.rustflags = Some(StringOrArray::String(rustflags));
+        }
+        if let Some(rustdocflags) = env::ver("CARGO_BUILD_RUSTDOCFLAGS")? {
+            self.build.rustdocflags = Some(StringOrArray::String(rustdocflags));
+        }
+        if let Some(target) = env::ver("CARGO_BUILD_TARGET")? {
+            self.build.target = Some(target);
+        }
+        if let Some(verbose) = env::ver("CARGO_TERM_VERBOSE")? {
+            self.term.verbose = Some(verbose.parse()?);
+        }
+        if let Some(color) = env::ver("CARGO_TERM_COLOR")? {
+            self.term.color =
+                Some(clap::ArgEnum::from_str(&color, false).map_err(|e| format_err!("{}", e))?);
+        }
+        Ok(())
+    }
+
+    pub(crate) fn merge_to(&self, args: &mut Args, env: &mut Env) {
+        // RUSTFLAGS environment variable is prefer over build.rustflags config value.
+        // https://doc.rust-lang.org/nightly/cargo/reference/config.html#buildrustflags
+        if env.rustflags.is_none() {
+            if let Some(rustflags) = &self.build.rustflags {
+                env.rustflags = Some(rustflags.to_string().into());
+            }
+        }
+        // RUSTDOCFLAGS environment variable is prefer over build.rustdocflags config value.
+        // https://doc.rust-lang.org/nightly/cargo/reference/config.html#buildrustdocflags
+        if env.rustdocflags.is_none() {
+            if let Some(rustdocflags) = &self.build.rustdocflags {
+                env.rustdocflags = Some(rustdocflags.to_string().into());
+            }
+        }
+        // https://doc.rust-lang.org/nightly/cargo/reference/config.html#buildrustc
+        if env.rustc.is_none() {
+            if let Some(rustc) = &self.build.rustc {
+                env.rustc = Some(rustc.into());
+            }
+        }
+        if args.target.is_none() {
+            args.target = self.build.target.clone();
+        }
+        if args.verbose == 0 && self.term.verbose.unwrap_or(false) {
+            args.verbose = 1;
+        }
+        if args.color.is_none() {
+            args.color = self.term.color;
+        }
+    }
+}
+
+// https://doc.rust-lang.org/nightly/cargo/reference/config.html#build
+#[derive(Debug, Default, Deserialize)]
+pub(crate) struct Build {
+    // https://doc.rust-lang.org/nightly/cargo/reference/config.html#buildrustc
+    pub(crate) rustc: Option<String>,
+    // https://doc.rust-lang.org/nightly/cargo/reference/config.html#buildrustflags
+    pub(crate) rustflags: Option<StringOrArray>,
+    // https://doc.rust-lang.org/nightly/cargo/reference/config.html#buildrustdocflags
+    pub(crate) rustdocflags: Option<StringOrArray>,
+    // https://doc.rust-lang.org/nightly/cargo/reference/config.html#buildtarget
+    pub(crate) target: Option<String>,
+}
+
+// https://doc.rust-lang.org/nightly/cargo/reference/config.html#doc
+#[derive(Debug, Default, Deserialize)]
+pub(crate) struct Doc {
+    // https://doc.rust-lang.org/nightly/cargo/reference/config.html#docbrowser
+    pub(crate) browser: Option<StringOrArray>,
+}
+
+// https://doc.rust-lang.org/nightly/cargo/reference/config.html#term
+#[derive(Debug, Default, Deserialize)]
+pub(crate) struct Term {
+    // https://doc.rust-lang.org/nightly/cargo/reference/config.html#termverbose
+    pub(crate) verbose: Option<bool>,
+    // https://doc.rust-lang.org/nightly/cargo/reference/config.html#termcolor
+    pub(crate) color: Option<Coloring>,
+}
+
+#[derive(Debug, Deserialize)]
+#[serde(untagged)]
+pub(crate) enum StringOrArray {
+    String(String),
+    Array(Vec<String>),
+}
+
+impl StringOrArray {
+    pub(crate) fn path_and_args(&self) -> Option<(&OsStr, Vec<&str>)> {
+        match self {
+            Self::String(s) => {
+                let mut s = s.split(' ');
+                let path = s.next()?;
+                Some((OsStr::new(path), s.collect()))
+            }
+            Self::Array(v) => {
+                let path = v.get(0)?;
+                Some((OsStr::new(path), v.iter().skip(1).map(String::as_str).collect()))
+            }
+        }
+    }
+}
+
+impl ToString for StringOrArray {
+    fn to_string(&self) -> String {
+        match self {
+            Self::String(s) => s.clone(),
+            Self::Array(v) => v.join(" "),
+        }
+    }
+}

--- a/src/env.rs
+++ b/src/env.rs
@@ -1,3 +1,4 @@
+pub(crate) use std::env::var_os;
 use std::{
     env,
     ffi::{OsStr, OsString},
@@ -59,10 +60,6 @@ impl Env {
                 }
             },
         })
-    }
-
-    pub(crate) fn rustc(&self) -> &OsStr {
-        self.rustc.as_deref().unwrap_or_else(|| OsStr::new("rustc"))
     }
 
     pub(crate) fn cargo(&self) -> &OsStr {

--- a/src/rustc.rs
+++ b/src/rustc.rs
@@ -1,0 +1,60 @@
+use std::ffi::{OsStr, OsString};
+
+use anyhow::{format_err, Context as _, Result};
+use camino::{Utf8Path, Utf8PathBuf};
+
+use crate::{env::Env, process::ProcessBuilder};
+
+#[derive(Debug)]
+pub(crate) struct Rustc {
+    path: OsString,
+    nightly: bool,
+    pub(crate) verbose_version: String,
+    pub(crate) host: String,
+}
+
+impl Rustc {
+    pub(crate) fn new(env: &Env, workspace_root: &Utf8Path) -> Result<Self> {
+        let path = env.rustc.as_deref().unwrap_or_else(|| OsStr::new("rustc"));
+        let version = cmd!(path, "--version").dir(workspace_root).read()?;
+        let nightly = version.contains("-nightly") || version.contains("-dev");
+        let mut rustc = Self {
+            path: path.into(),
+            nightly,
+            verbose_version: String::new(),
+            host: String::new(),
+        };
+
+        let mut cmd = rustc.nightly_process();
+        cmd.args(&["--version", "--verbose"]);
+        rustc.verbose_version = cmd.read()?;
+        rustc.host = rustc
+            .verbose_version
+            .lines()
+            .find_map(|line| line.strip_prefix("host: "))
+            .ok_or_else(|| {
+                format_err!("unexpected version output from `{}`: {}", cmd, rustc.verbose_version)
+            })?
+            .to_owned();
+
+        Ok(rustc)
+    }
+
+    fn nightly_process(&self) -> ProcessBuilder {
+        if self.nightly {
+            cmd!(&self.path)
+        } else {
+            cmd!("rustup", "run", "nightly", "rustc")
+        }
+    }
+}
+
+pub(crate) fn sysroot(rustc: &Rustc) -> Result<Utf8PathBuf> {
+    Ok(rustc
+        .nightly_process()
+        .args(&["--print", "sysroot"])
+        .read()
+        .context("failed to find sysroot")?
+        .trim()
+        .into())
+}

--- a/tests/long-help.txt
+++ b/tests/long-help.txt
@@ -5,7 +5,7 @@ Cargo subcommand to easily use LLVM source-based code coverage (-Z instrument-co
 Use -h for short descriptions and --help for more details.
 
 USAGE:
-    cargo llvm-cov [OPTIONS] [-- <ARGS>...]
+    cargo llvm-cov [OPTIONS] [-- <ARGS>...] [SUBCOMMAND]
 
 ARGS:
     <ARGS>...
@@ -186,3 +186,9 @@ OPTIONS:
 
     -Z <FLAG>...
             Unstable (nightly-only) flags to Cargo
+
+SUBCOMMANDS:
+    clean
+            Remove artifacts that cargo-llvm-cov has generated in the past
+    help
+            Print this message or the help of the given subcommand(s)

--- a/tests/short-help.txt
+++ b/tests/short-help.txt
@@ -5,7 +5,7 @@ Cargo subcommand to easily use LLVM source-based code coverage (-Z instrument-co
 Use -h for short descriptions and --help for more details.
 
 USAGE:
-    cargo llvm-cov [OPTIONS] [-- <ARGS>...]
+    cargo llvm-cov [OPTIONS] [-- <ARGS>...] [SUBCOMMAND]
 
 ARGS:
     <ARGS>...    Arguments for the test binary
@@ -143,3 +143,7 @@ OPTIONS:
 
     -Z <FLAG>...
             Unstable (nightly-only) flags to Cargo
+
+SUBCOMMANDS:
+    clean    Remove artifacts that cargo-llvm-cov has generated in the past
+    help     Print this message or the help of the given subcommand(s)


### PR DESCRIPTION
```console
$ cargo llvm-cov clean --help
cargo-llvm-cov-clean 

Remove artifacts that cargo-llvm-cov has generated in the past

USAGE:
    cargo llvm-cov clean

OPTIONS:
        --manifest-path <PATH>    Path to Cargo.toml
        --color <WHEN>            Coloring [possible values: auto, always, never]
    -h, --help                    Print help information
```

This also improves heuristics around artifact cleanup.

Closes #69