### PR TITLE
Fix bug with auto-ignored paths

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -599,7 +599,7 @@ fn resolve_excluded_paths(cx: &Context) -> Vec<Utf8PathBuf> {
         for &manifest_dir in &excluded {
             let package_path =
                 manifest_dir.strip_prefix(&cx.ws.metadata.workspace_root).unwrap_or(manifest_dir);
-            excluded_path.push(package_path.into());
+            excluded_path.push(package_path.join("").into());
         }
         return excluded_path;
     }
@@ -610,7 +610,7 @@ fn resolve_excluded_paths(cx: &Context) -> Vec<Utf8PathBuf> {
             None => {
                 let package_path =
                     excluded.strip_prefix(&cx.ws.metadata.workspace_root).unwrap_or(excluded);
-                excluded_path.push(package_path.into());
+                excluded_path.push(package_path.join("").into());
                 continue;
             }
         };

--- a/src/main.rs
+++ b/src/main.rs
@@ -599,7 +599,7 @@ fn resolve_excluded_paths(cx: &Context) -> Vec<Utf8PathBuf> {
         for &manifest_dir in &excluded {
             let package_path =
                 manifest_dir.strip_prefix(&cx.ws.metadata.workspace_root).unwrap_or(manifest_dir);
-            excluded_path.push(package_path.join("").into());
+            excluded_path.push(package_path.join(""));
         }
         return excluded_path;
     }
@@ -610,7 +610,7 @@ fn resolve_excluded_paths(cx: &Context) -> Vec<Utf8PathBuf> {
             None => {
                 let package_path =
                     excluded.strip_prefix(&cx.ws.metadata.workspace_root).unwrap_or(excluded);
-                excluded_path.push(package_path.join("").into());
+                excluded_path.push(package_path.join(""));
                 continue;
             }
         };

--- a/src/main.rs
+++ b/src/main.rs
@@ -639,7 +639,7 @@ fn resolve_excluded_paths(cx: &Context) -> Vec<Utf8PathBuf> {
                 return true;
             }
             let p = p.strip_prefix(&cx.ws.metadata.workspace_root).unwrap_or(p);
-            excluded_path.push(p.to_owned().try_into().unwrap());
+            excluded_path.push(p.join("").try_into().unwrap());
             false
         }) {}
     }


### PR DESCRIPTION
cargo llvm-cov currently adds all the workspace members
except the one you're currently working in to the regex
passed to -ignore-filename-regex. They are added as
paths to their package directories, without a trailing
path separator. This means that if you have a workspace
with the two members 'foo' and 'food', and you enter
the directory 'food' and type 'cargo llvm-cov --html',
you will get an empty report since the path 'food' has
'foo' as a prefix, and 'foo' has been automatically added
to the ignore list.

This patch fixes this problem by adding a trailing path
separator to all the workspace members added to the
regex. 'food' does not have 'foo/' as a prefix, so the
example above should now work.