### PR TITLE
Exclude CARGO_HOME and RUSTUP_HOME used in official docker image from reports

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,8 @@ Note: In this file, do not use the hard wrap in the middle of a sentence for com
 
 ## [Unreleased]
 
+- Exclude `CARGO_HOME` and `RUSTUP_HOME` used in the official rust docker image from reports. ([#105](https://github.com/taiki-e/cargo-llvm-cov/pull/105))
+
 ## [0.1.11] - 2021-11-13
 
 - Fix ["conflicting weak extern definition" error](https://github.com/rust-lang/rust/issues/85461) on windows. ([#101](https://github.com/taiki-e/cargo-llvm-cov/pull/101))

--- a/README.md
+++ b/README.md
@@ -299,6 +299,12 @@ cargo llvm-cov --no-report --features b
 cargo llvm-cov --no-run --lcov
 ```
 
+To exclude specific file patterns from the report, use the `--ignore-filename-regex` option.
+
+```sh
+cargo llvm-cov --open --ignore-filename-regex build
+```
+
 ### Continuous Integration
 
 Here is an example of GitHub Actions workflow that uploads coverage to [Codecov].

--- a/src/main.rs
+++ b/src/main.rs
@@ -537,8 +537,9 @@ fn ignore_filename_regex(cx: &Context) -> Option<String> {
     fn default_ignore_filename_regex() -> String {
         // TODO: Should we use the actual target path instead of using `tests|examples|benches`?
         //       We may have a directory like tests/support, so maybe we need both?
+        // TODO: Check CARGO_HOME and RUSTUP_HOME env var instead of hard coding (.)?cargo/(.)?rustup
         format!(
-            r"(^|{0})(rustc{0}[0-9a-f]+|.cargo{0}(registry|git)|.rustup{0}toolchains|tests|examples|benches|target{0}llvm-cov-target){0}",
+            r"(^|{0})(rustc{0}[0-9a-f]+|(\.)?cargo{0}(registry|git)|(\.)?rustup{0}toolchains|tests|examples|benches|target{0}llvm-cov-target){0}",
             SEPARATOR
         )
     }


### PR DESCRIPTION
This also adds a description of --ignore-filename-regex, a flag to
handle such cases on the user side, to the readme.

Fixes #104 