### PR TITLE
Use --target-dir in favor of `CARGO_TARGET_DIR`

### DIFF
--- a/src/cargo.rs
+++ b/src/cargo.rs
@@ -254,6 +254,9 @@ pub(crate) fn test_args(cx: &Context, args: &Args, cmd: &mut ProcessBuilder) {
     cmd.arg("--manifest-path");
     cmd.arg(&cx.ws.current_manifest);
 
+    cmd.arg("--target-dir");
+    cmd.arg(&cx.ws.target_dir);
+
     cx.build.cargo_args(cmd);
     cx.manifest.cargo_args(cmd);
 
@@ -290,6 +293,9 @@ pub(crate) fn run_args(cx: &Context, args: &RunOptions, cmd: &mut ProcessBuilder
     cmd.arg("--manifest-path");
     cmd.arg(&cx.ws.current_manifest);
 
+    cmd.arg("--target-dir");
+    cmd.arg(&cx.ws.target_dir);
+
     cx.build.cargo_args(cmd);
     cx.manifest.cargo_args(cmd);
 
@@ -324,6 +330,12 @@ pub(crate) fn clean_args(cx: &Context, cmd: &mut ProcessBuilder) {
         cmd.arg("--color");
         cmd.arg(color.cargo_color());
     }
+
+    cmd.arg("--manifest-path");
+    cmd.arg(&cx.ws.current_manifest);
+
+    cmd.arg("--target-dir");
+    cmd.arg(&cx.ws.target_dir);
 
     cx.manifest.cargo_args(cmd);
 

--- a/src/clean.rs
+++ b/src/clean.rs
@@ -135,7 +135,7 @@ fn pkg_hash_re(ws: &Workspace, pkg_ids: &[PackageId]) -> Regex {
 }
 
 fn clean_trybuild_artifacts(ws: &Workspace, pkg_ids: &[PackageId], verbose: bool) -> Result<()> {
-    let trybuild_dir = &ws.target_dir.join("tests");
+    let trybuild_dir = &ws.metadata.target_directory.join("tests");
     let trybuild_target = &trybuild_dir.join("target");
     let re = pkg_hash_re(ws, pkg_ids);
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -198,7 +198,6 @@ fn set_env(cx: &Context, cmd: &mut ProcessBuilder) {
     }
     cmd.env("LLVM_PROFILE_FILE", &*llvm_profile_file);
     cmd.env("CARGO_INCREMENTAL", "0");
-    cmd.env("CARGO_TARGET_DIR", &cx.ws.target_dir);
 }
 
 fn run_test(cx: &Context, args: &Args) -> Result<()> {
@@ -341,7 +340,7 @@ fn object_files(cx: &Context) -> Result<Vec<OsString>> {
     }
 
     // trybuild
-    let trybuild_dir = &cx.ws.target_dir.join("tests");
+    let trybuild_dir = &cx.ws.metadata.target_directory.join("tests");
     let mut trybuild_target = trybuild_dir.join("target");
     if let Some(target) = &cx.build.target {
         trybuild_target.push(target);
@@ -350,7 +349,7 @@ fn object_files(cx: &Context) -> Result<Vec<OsString>> {
     trybuild_target.push("debug");
     if trybuild_target.is_dir() {
         let mut trybuild_targets = vec![];
-        for metadata in trybuild_metadata(&cx.ws.target_dir)? {
+        for metadata in trybuild_metadata(&cx.ws.metadata.target_directory)? {
             for package in metadata.packages {
                 for target in package.targets {
                     trybuild_targets.push(target.name);

--- a/tests/auxiliary/mod.rs
+++ b/tests/auxiliary/mod.rs
@@ -27,7 +27,6 @@ pub fn cargo_llvm_cov() -> Command {
     cmd.arg("llvm-cov");
     cmd.env_remove("RUSTFLAGS")
         .env_remove("RUSTDOCFLAGS")
-        .env_remove("CARGO_TARGET_DIR")
         .env_remove("CARGO_BUILD_RUSTFLAGS")
         .env_remove("CARGO_BUILD_RUSTDOCFLAGS")
         .env_remove("CARGO_TERM_VERBOSE")


### PR DESCRIPTION
Sorry it has taken me to long to get to this.

Please note that I also adjusted `clean_args` to set `--manifest-path`, as this seemed like the desired behavior.

Closes #100