### PR TITLE
cli: add show-env subcommand

### DIFF
--- a/README.md
+++ b/README.md
@@ -298,6 +298,16 @@ cargo llvm-cov --no-report --features b
 cargo llvm-cov --no-run --lcov
 ```
 
+In combination with the `show-env` subcommand, coverage can also be produced from arbitrary binaries:
+
+```sh
+cargo llvm-cov clean --workspace # remove artifacts that may affect the coverage results
+source (cargo llvm-cov show-env --export-prefix)
+cargo build # build rust binaries
+# commands using binaries in target/debug/*, including `cargo test`
+cargo llvm-cov --no-run --lcov
+```
+
 To exclude specific file patterns from the report, use the `--ignore-filename-regex` option.
 
 ```sh

--- a/README.md
+++ b/README.md
@@ -302,7 +302,7 @@ In combination with the `show-env` subcommand, coverage can also be produced fro
 
 ```sh
 cargo llvm-cov clean --workspace # remove artifacts that may affect the coverage results
-source (cargo llvm-cov show-env --export-prefix)
+source <(cargo llvm-cov show-env --export-prefix)
 cargo build # build rust binaries
 # commands using binaries in target/debug/*, including `cargo test`
 cargo llvm-cov --no-run --lcov

--- a/README.md
+++ b/README.md
@@ -305,7 +305,8 @@ cargo llvm-cov clean --workspace # remove artifacts that may affect the coverage
 source <(cargo llvm-cov show-env --export-prefix)
 cargo build # build rust binaries
 # commands using binaries in target/debug/*, including `cargo test`
-cargo llvm-cov --no-run --lcov
+# ...
+cargo llvm-cov --no-run --lcov # generate report without tests
 ```
 
 To exclude specific file patterns from the report, use the `--ignore-filename-regex` option.

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -177,6 +177,14 @@ pub(crate) enum Subcommand {
     )]
     Run(Box<RunOptions>),
 
+    /// Output the environment set by cargo-llvm-cov to build Rust projects.
+    #[clap(
+        bin_name = "cargo llvm-cov show-env",
+        max_term_width = MAX_TERM_WIDTH,
+        setting = AppSettings::DeriveDisplayOrder,
+    )]
+    ShowEnv,
+
     /// Remove artifacts that cargo-llvm-cov has generated in the past
     #[clap(
         bin_name = "cargo llvm-cov clean",

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -183,7 +183,7 @@ pub(crate) enum Subcommand {
         max_term_width = MAX_TERM_WIDTH,
         setting = AppSettings::DeriveDisplayOrder,
     )]
-    ShowEnv,
+    ShowEnv(ShowEnvOptions),
 
     /// Remove artifacts that cargo-llvm-cov has generated in the past
     #[clap(
@@ -436,6 +436,13 @@ impl RunOptions {
     pub(crate) fn manifest(&mut self) -> ManifestOptions {
         mem::take(&mut self.manifest)
     }
+}
+
+#[derive(Debug, Parser)]
+pub(crate) struct ShowEnvOptions {
+    /// Prepend "export " to each line, so that the output is suitable to be sourced by bash.
+    #[clap(long)]
+    pub(crate) export_prefix: bool,
 }
 
 #[derive(Debug, Parser)]

--- a/tests/long-help.txt
+++ b/tests/long-help.txt
@@ -196,6 +196,8 @@ OPTIONS:
 SUBCOMMANDS:
     run
             Run a binary or example and generate coverage report
+    show-env
+            Output the environment set by cargo-llvm-cov to build Rust projects
     clean
             Remove artifacts that cargo-llvm-cov has generated in the past
     help

--- a/tests/short-help.txt
+++ b/tests/short-help.txt
@@ -147,6 +147,7 @@ OPTIONS:
             Print version information
 
 SUBCOMMANDS:
-    run      Run a binary or example and generate coverage report
-    clean    Remove artifacts that cargo-llvm-cov has generated in the past
-    help     Print this message or the help of the given subcommand(s)
+    run         Run a binary or example and generate coverage report
+    show-env    Output the environment set by cargo-llvm-cov to build Rust projects
+    clean       Remove artifacts that cargo-llvm-cov has generated in the past
+    help        Print this message or the help of the given subcommand(s)


### PR DESCRIPTION
Implements the `show-env` suggestion from https://github.com/taiki-e/cargo-llvm-cov/issues/93#issuecomment-922911124

An example output:

```
$ cargo llvm-cov show-env
RUSTFLAGS=" -Z instrument-coverage --remap-path-prefix /home/david/dev/pyo3/= --cfg coverage --cfg trybuild_no_target"
LLVM_PROFILE_FILE="/home/david/dev/pyo3/target/llvm-cov-target/pyo3-%m.profraw"
CARGO_INCREMENTAL="0"
CARGO_TARGET_DIR="/home/david/dev/pyo3/target/llvm-cov-target"
```

After exporting these vars, I had a go at building pyo3's `cdylib` examples and then running them with `pytest`.

Pleased to see that I do get profile output in the expected location:

```
$ ls target/llvm-cov-target/
CACHEDIR.TAG                         pyo3-6622988374613674511_0.profraw
debug                                pyo3-8390305564713967804_0.profraw
pyo3-10144924340354712083_0.profraw  pyo3-8655209440434687052_0.profraw
pyo3-12448306348928428713_0.profraw  pyo3-9115749969700858718_0.profraw
pyo3-13212718739740305352_0.profraw  pyo3-9296542518232051450_0.profraw
pyo3-17208771140764127027_0.profraw  pyo3.profdata
pyo3-40338836728015828_0.profraw     release
pyo3-5761173678925874245_0.profraw   wheels
pyo3-6135639819960792837_0.profraw
```

There's still some pain points:
  1. I need to unset `CARGO_TARGET_DIR` before attempting to run `cargo llvm-cov` command, or I get crashes because it tries to append `llvm-cov-target` for a second time:
  
  ```
  $ cargo llvm-cov --no-run --summary-only
  error: no input files specified. See llvm-profdata merge -help
  error: failed to merge profile data: process didn't exit successfully: `/home/david/.rustup/toolchains/nightly-x86_64-unknown-linux-gnu/lib/rustlib/x86_64-unknown-linux-gnu/bin/llvm-profdata merge -sparse -o /home/david/dev/pyo3/target/llvm-cov-target/llvm-cov-target/pyo3.profdata` (exit status: 1)
  ```
  
  2. After unsetting `CARGO_TARGET_DIR`, I still get a failure to generate the report. I suspect this is because `cargo-llvm-cov` is not finding and passing the `cdylib` outputs to `llvm-cov report`?
  
  ```
  $ cargo llvm-cov --no-run --summary-only --verbose
     Running `/home/david/.rustup/toolchains/nightly-x86_64-unknown-linux-gnu/lib/rustlib/x86_64-unknown-linux-gnu/bin/llvm-profdata merge -sparse /home/david/dev/pyo3/target/llvm-cov-target/pyo3-10144924340354712083_0.profraw /home/david/dev/pyo3/target/llvm-cov-target/pyo3-12448306348928428713_0.profraw /home/david/dev/pyo3/target/llvm-cov-target/pyo3-13212718739740305352_0.profraw /home/david/dev/pyo3/target/llvm-cov-target/pyo3-17208771140764127027_0.profraw /home/david/dev/pyo3/target/llvm-cov-target/pyo3-40338836728015828_0.profraw /home/david/dev/pyo3/target/llvm-cov-target/pyo3-5761173678925874245_0.profraw /home/david/dev/pyo3/target/llvm-cov-target/pyo3-6135639819960792837_0.profraw /home/david/dev/pyo3/target/llvm-cov-target/pyo3-6622988374613674511_0.profraw /home/david/dev/pyo3/target/llvm-cov-target/pyo3-8390305564713967804_0.profraw /home/david/dev/pyo3/target/llvm-cov-target/pyo3-8655209440434687052_0.profraw /home/david/dev/pyo3/target/llvm-cov-target/pyo3-9115749969700858718_0.profraw /home/david/dev/pyo3/target/llvm-cov-target/pyo3-9296542518232051450_0.profraw -o /home/david/dev/pyo3/target/llvm-cov-target/pyo3.profdata`
     Running `/home/david/.rustup/toolchains/nightly-x86_64-unknown-linux-gnu/lib/rustlib/x86_64-unknown-linux-gnu/bin/llvm-cov report -instr-profile=/home/david/dev/pyo3/target/llvm-cov-target/pyo3.profdata -ignore-filename-regex '(^|/)(rustc/[0-9a-f]+|(\.)?cargo/(registry|git)|(\.)?rustup/toolchains|tests|examples|benches|target/llvm-cov-target)/|^/home/david/|^pyo3-macros/|^pyo3-macros-backend/|^pyo3-build-config/|^examples/|^xtask/'`
  No filenames specified!
  error: failed to generate report: process didn't exit successfully: `/home/david/.rustup/toolchains/nightly-x86_64-unknown-linux-gnu/lib/rustlib/x86_64-unknown-linux-gnu/bin/llvm-cov report -instr-profile=/home/david/dev/pyo3/target/llvm-cov-target/pyo3.profdata -ignore-filename-regex '(^|/)(rustc/[0-9a-f]+|(\.)?cargo/(registry|git)|(\.)?rustup/toolchains|tests|examples|benches|target/llvm-cov-target)/|^/home/david/|^pyo3-macros/|^pyo3-macros-backend/|^pyo3-build-config/|^examples/|^xtask/'` (exit status: 1)
   ```
   
If you're interested, you can see the companion PyO3 at https://github.com/PyO3/pyo3/pull/2067

