### PR TITLE
Update to stabilized `-C instrument-coverage`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,12 @@ Note: In this file, do not use the hard wrap in the middle of a sentence for com
 
 ## [Unreleased]
 
+- Update to stabilized `-C instrument-coverage`. ([#130](https://github.com/taiki-e/cargo-llvm-cov/pull/130))
+
+  Support for `-Z instrument-coverage` in the old nightly will also be kept for compatibility.
+
+  **Compatibility Note:** In 0.1, if `-C instrument-coverage` or `-Z instrument-coverage` is not available in the default toolchain, running `cargo llvm-cov` will find and use nightly. This behavior will be changed in 0.2 to always select the default toolchain. If you are likely to be affected by the change in 0.2, cargo-llvm-cov will emit a warning.
+
 ## [0.1.16] - 2022-01-21
 
 - Alleviate an issue where "File name or extension is too long" error occurs in Windows. ([#126](https://github.com/taiki-e/cargo-llvm-cov/pull/126), thanks @aganders3)

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,7 +9,7 @@ keywords = ["cargo", "coverage", "subcommand", "testing"]
 categories = ["command-line-utilities", "development-tools", "development-tools::cargo-plugins", "development-tools::testing"]
 exclude = ["/.*", "/tools"]
 description = """
-Cargo subcommand to easily use LLVM source-based code coverage (-Z instrument-coverage).
+Cargo subcommand to easily use LLVM source-based code coverage (-C instrument-coverage).
 """
 
 [package.metadata.docs.rs]

--- a/README.md
+++ b/README.md
@@ -7,12 +7,12 @@
 
 Cargo subcommand to easily use LLVM source-based code coverage.
 
-This is a wrapper around rustc [`-Z instrument-coverage`][instrument-coverage] and provides:
+This is a wrapper around rustc [`-C instrument-coverage`][instrument-coverage] and provides:
 
 - Generate very precise coverage data. (line coverage and region coverage)
 - Support both `cargo test` and `cargo run`.
 - Support for proc-macro, including coverage of UI tests.
-- Support for doc tests. (this is currently optional, see [#2] for more)
+- Support for doc tests. (this is currently optional and requires nightly, see [#2] for more)
 - Command-line interface compatible with cargo.
 
 **Table of Contents:**
@@ -34,7 +34,7 @@ This is a wrapper around rustc [`-Z instrument-coverage`][instrument-coverage] a
 ```console
 $ cargo llvm-cov --help
 cargo-llvm-cov
-Cargo subcommand to easily use LLVM source-based code coverage (-Z instrument-coverage).
+Cargo subcommand to easily use LLVM source-based code coverage (-C instrument-coverage).
 
 Use -h for short descriptions and --help for more details.
 
@@ -382,11 +382,7 @@ rustup component add llvm-tools-preview --toolchain nightly
 cargo install cargo-llvm-cov
 ```
 
-cargo-llvm-cov relies on unstable compiler flags so it requires a nightly
-toolchain to be installed, though does not require nightly to be the default
-toolchain or the one with which cargo-llvm-cov itself is executed. If the
-default toolchain is one other than nightly, running `cargo llvm-cov` will find
-and use nightly.
+If `-C instrument-coverage` or `-Z instrument-coverage` is not available in the default toolchain, running `cargo llvm-cov` will find and use nightly. This behavior will be changed in 0.2 to always select the default toolchain.
 
 Currently, installing cargo-llvm-cov requires rustc 1.54+.
 
@@ -409,7 +405,7 @@ This makes the installation faster and may avoid the impact of [problems caused 
 <!-- omit in toc -->
 ### Via Homebrew
 
-You can install cargo-llvm-cov using [Homebrew tap on macOS and Linux](https://github.com/taiki-e/homebrew-tap/blob/main/Formula/cargo-llvm-cov.rb):
+You can install cargo-llvm-cov using [Homebrew tap on macOS and Linux](https://github.com/taiki-e/homebrew-tap/blob/HEAD/Formula/cargo-llvm-cov.rb):
 
 ```sh
 brew install taiki-e/tap/cargo-llvm-cov
@@ -446,7 +442,7 @@ See also [the code-coverage-related issues reported in rust-lang/rust](https://g
 [cargo-hack]: https://github.com/taiki-e/cargo-hack
 [cargo-minimal-versions]: https://github.com/taiki-e/cargo-minimal-versions
 [codecov]: https://codecov.io
-[instrument-coverage]: https://doc.rust-lang.org/nightly/unstable-book/compiler-flags/instrument-coverage.html
+[instrument-coverage]: https://doc.rust-lang.org/nightly/rustc/instrument-coverage.html
 [rust-lang/rust#79417]: https://github.com/rust-lang/rust/issues/79417
 [rust-lang/rust#79649]: https://github.com/rust-lang/rust/issues/79649
 [rust-lang/rust#84605]: https://github.com/rust-lang/rust/issues/84605

--- a/src/clean.rs
+++ b/src/clean.rs
@@ -17,7 +17,7 @@ use crate::{
 };
 
 pub(crate) fn run(mut options: CleanOptions) -> Result<()> {
-    let ws = Workspace::new(&options.manifest, None, false)?;
+    let ws = Workspace::new(&options.manifest, None, false, false)?;
     ws.config.merge_to_args(&mut None, &mut options.verbose, &mut options.color);
     term::set_coloring(&mut options.color);
 

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -6,7 +6,7 @@ use clap::{AppSettings, ArgSettings, Parser};
 use crate::{process::ProcessBuilder, term::Coloring};
 
 const ABOUT: &str =
-    "Cargo subcommand to easily use LLVM source-based code coverage (-Z instrument-coverage).
+    "Cargo subcommand to easily use LLVM source-based code coverage (-C instrument-coverage).
 
 Use -h for short descriptions and --help for more details.";
 

--- a/src/config.rs
+++ b/src/config.rs
@@ -36,8 +36,9 @@ impl Config {
         // https://doc.rust-lang.org/nightly/cargo/reference/unstable.html#cargo-config
         // https://github.com/rust-lang/cargo/issues/9301
         cargo
-            .args(["-Z", "unstable-options", "config", "get", "--format", "json"])
-            .dir(workspace_root);
+            .args(&["-Z", "unstable-options", "config", "get", "--format", "json"])
+            .dir(workspace_root)
+            .env("RUSTC_BOOTSTRAP", "1");
         let mut config = match cargo.read() {
             Ok(s) => serde_json::from_str(&s)
                 .with_context(|| format!("failed to parse output from {}", cargo))?,

--- a/src/context.rs
+++ b/src/context.rs
@@ -50,7 +50,7 @@ impl Context {
         no_run: bool,
         show_env: bool,
     ) -> Result<Self> {
-        let ws = Workspace::new(&manifest, build.target.as_deref(), show_env)?;
+        let ws = Workspace::new(&manifest, build.target.as_deref(), doctests, show_env)?;
         ws.config.merge_to_args(&mut build.target, &mut build.verbose, &mut build.color);
         term::set_coloring(&mut build.color);
         term::verbose::set(build.verbose != 0);
@@ -95,7 +95,7 @@ impl Context {
         if !llvm_cov.exists() || !llvm_profdata.exists() {
             bail!(
                 "failed to find llvm-tools-preview, please install llvm-tools-preview with `rustup component add llvm-tools-preview{}`",
-                if ws.nightly { "" } else { " --toolchain nightly" }
+                if ws.force_nightly { " --toolchain nightly" } else { "" }
             );
         }
 

--- a/tests/long-help.txt
+++ b/tests/long-help.txt
@@ -1,5 +1,5 @@
 cargo-llvm-cov
-Cargo subcommand to easily use LLVM source-based code coverage (-Z instrument-coverage).
+Cargo subcommand to easily use LLVM source-based code coverage (-C instrument-coverage).
 
 Use -h for short descriptions and --help for more details.
 

--- a/tests/short-help.txt
+++ b/tests/short-help.txt
@@ -1,5 +1,5 @@
 cargo-llvm-cov
-Cargo subcommand to easily use LLVM source-based code coverage (-Z instrument-coverage).
+Cargo subcommand to easily use LLVM source-based code coverage (-C instrument-coverage).
 
 Use -h for short descriptions and --help for more details.
 


### PR DESCRIPTION
Closes #129 

Support for `-Z instrument-coverage` in the old nightly will also be kept for compatibility.