### PR TITLE
feat: add cargo nextest support

### DIFF
--- a/README.md
+++ b/README.md
@@ -247,6 +247,8 @@ SUBCOMMANDS:
             Output the environment set by cargo-llvm-cov to build Rust projects
     clean
             Remove artifacts that cargo-llvm-cov has generated in the past
+    nextest
+            Run tests with cargo nextest
     help
             Print this message or the help of the given subcommand(s)
 ```

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -199,6 +199,19 @@ pub(crate) enum Subcommand {
     )]
     Clean(CleanOptions),
 
+    /// Run tests with cargo nextest
+    #[clap(
+        bin_name = "cargo llvm-cov nextest",
+        max_term_width(MAX_TERM_WIDTH),
+        setting(AppSettings::DeriveDisplayOrder),
+        trailing_var_arg = true,
+        allow_hyphen_values = true
+    )]
+    Nextest {
+        #[clap(multiple_values = true)]
+        passthrough_options: Vec<String>,
+    },
+
     // internal (unstable)
     #[clap(
         bin_name = "cargo llvm-cov demangle",

--- a/src/main.rs
+++ b/src/main.rs
@@ -312,6 +312,10 @@ fn run_nextest(cx: &Context, args: &Args) -> Result<()> {
 
     cargo.arg("nextest").arg("run");
 
+    if cx.doctests {
+        return Err(anyhow::anyhow!("doctest is not supported for nextest"));
+    }
+
     cargo::test_args(cx, args, &mut cargo);
 
     if term::verbose() {

--- a/src/main.rs
+++ b/src/main.rs
@@ -100,6 +100,37 @@ fn try_main() -> Result<()> {
             writer.set("CARGO_LLVM_COV_TARGET_DIR", cx.ws.metadata.target_directory.as_str());
         }
 
+        Some(Subcommand::Nextest { passthrough_options }) => {
+            let cx = &context_from_args(
+                &mut Args::try_parse_from(
+                    [
+                        // fake argv[0] to help clap parse
+                        "nextest".to_string(),
+                    ]
+                    .iter()
+                    // real pass-through args
+                    .chain(passthrough_options.iter()),
+                )?,
+                false,
+            )?;
+
+            clean::clean_partial(cx)?;
+            create_dirs(cx)?;
+            match (args.no_run, cx.cov.no_report) {
+                (false, false) => {
+                    run_nextest(cx, &args)?;
+                    generate_report(cx)?;
+                }
+                (false, true) => {
+                    run_nextest(cx, &args)?;
+                }
+                (true, false) => {
+                    generate_report(cx)?;
+                }
+                (true, true) => unreachable!(),
+            }
+        }
+
         None => {
             let cx = &context_from_args(&mut args, false)?;
             let tmp = term::warn(); // The following warnings should not be promoted to an error.
@@ -265,6 +296,22 @@ fn run_test(cx: &Context, args: &Args) -> Result<()> {
         cargo.arg("-Z");
         cargo.arg("doctest-in-workspace");
     }
+    cargo::test_args(cx, args, &mut cargo);
+
+    if term::verbose() {
+        status!("Running", "{}", cargo);
+    }
+    cargo.stdout_to_stderr().run()?;
+    Ok(())
+}
+
+fn run_nextest(cx: &Context, args: &Args) -> Result<()> {
+    let mut cargo = cx.cargo();
+
+    set_env(cx, &mut cargo);
+
+    cargo.arg("nextest").arg("run");
+
     cargo::test_args(cx, args, &mut cargo);
 
     if term::verbose() {

--- a/tests/long-help.txt
+++ b/tests/long-help.txt
@@ -212,5 +212,7 @@ SUBCOMMANDS:
             Output the environment set by cargo-llvm-cov to build Rust projects
     clean
             Remove artifacts that cargo-llvm-cov has generated in the past
+    nextest
+            Run tests with cargo nextest
     help
             Print this message or the help of the given subcommand(s)

--- a/tests/short-help.txt
+++ b/tests/short-help.txt
@@ -162,4 +162,5 @@ SUBCOMMANDS:
     run         Run a binary or example and generate coverage report
     show-env    Output the environment set by cargo-llvm-cov to build Rust projects
     clean       Remove artifacts that cargo-llvm-cov has generated in the past
+    nextest     Run tests with cargo nextest
     help        Print this message or the help of the given subcommand(s)


### PR DESCRIPTION
Signed-off-by: Alex Chi <iskyzh@gmail.com>

[cargo-nextest](https://github.com/nextest-rs/nextest/) is quite popular recently, but it lacks coverage support. In this PR, I added a new `nextest` command to run tests.

I've tested it locally and it works. On my own project, it shows (nearly) the same coverage as normal `cargo llvm-cov`.

```
cargo llvm-cov nextest
```

Not sure if it is good to simply add a `nextest` command... Maybe it would be better to allow users to run arbitrary command in `cargo llvm-cov <user command>`?

Thanks for reviewing!