### PR TITLE
Exclude target dir properly even if target dir is changed from default

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,8 @@ Note: In this file, do not use the hard wrap in the middle of a sentence for com
 
 ## [Unreleased]
 
+- Fix an issue where codes in the target directory are not being properly excluded from reports when using `show-env` subcommand. ([#156](https://github.com/taiki-e/cargo-llvm-cov/pull/156))
+
 ## [0.3.2] - 2022-05-05
 
 - Alleviate an issue where "File name or extension is too long" error occurs in Windows. ([#155](https://github.com/taiki-e/cargo-llvm-cov/pull/155))

--- a/src/main.rs
+++ b/src/main.rs
@@ -721,10 +721,7 @@ fn ignore_filename_regex(cx: &Context) -> Option<String> {
     fn default_ignore_filename_regex() -> String {
         // TODO: Should we use the actual target path instead of using `tests|examples|benches`?
         //       We may have a directory like tests/support, so maybe we need both?
-        format!(
-            r"(^|{0})(rustc{0}[0-9a-f]+|tests|examples|benches|target{0}llvm-cov-target){0}",
-            SEPARATOR
-        )
+        format!(r"(^|{0})(rustc{0}[0-9a-f]+|tests|examples|benches){0}", SEPARATOR)
     }
 
     #[derive(Default)]
@@ -758,6 +755,7 @@ fn ignore_filename_regex(cx: &Context) -> Option<String> {
     }
     if !cx.cov.disable_default_ignore_filename_regex {
         out.push(default_ignore_filename_regex());
+        out.push_abs_path(&cx.ws.target_dir);
         if cx.build.remap_path_prefix {
             for path in [home::home_dir(), home::cargo_home().ok(), home::rustup_home().ok()]
                 .iter()


### PR DESCRIPTION
This fixes an issue where codes in the target directory are not being properly excluded from reports when using `show-env` subcommand.