### PR TITLE
fix: add `--coverage-target-only`, to use rustflags only for target

### DIFF
--- a/README.md
+++ b/README.md
@@ -215,6 +215,13 @@ OPTIONS:
             When this option is used, coverage for proc-macro and build script will not be displayed
             because cargo does not pass RUSTFLAGS to them.
 
+        --coverage-target-only
+            Activate coverage reporting only for the target triple
+
+            Activate coverage reporting only for the target triple specified via `--target`. This is
+            important, if the project uses multiple targets via the cargo bindeps feature, and not
+            all targets can use `instrument-coverage`, e.g. a microkernel, or an embedded binary.
+
     -v, --verbose
             Use verbose output
 

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -357,6 +357,14 @@ pub(crate) struct BuildOptions {
     /// not be displayed because cargo does not pass RUSTFLAGS to them.
     #[clap(long, value_name = "TRIPLE")]
     pub(crate) target: Option<String>,
+    /// Activate coverage reporting only for the target triple
+    ///
+    /// Activate coverage reporting only for the target triple specified via `--target`.
+    /// This is important, if the project uses multiple targets via the cargo
+    /// bindeps feature, and not all targets can use `instrument-coverage`,
+    /// e.g. a microkernel, or an embedded binary.
+    #[clap(long, requires = "target")]
+    pub(crate) coverage_target_only: bool,
     // TODO: Currently, we are using a subdirectory of the target directory as
     //       the actual target directory. What effect should this option have
     //       on its behavior?

--- a/src/main.rs
+++ b/src/main.rs
@@ -274,7 +274,14 @@ fn set_env(cx: &Context, target: &mut impl EnvTarget) {
         }
     }
 
-    target.set("RUSTFLAGS", rustflags);
+    match (cx.build.coverage_target_only, &cx.build.target) {
+        (true, Some(coverage_target)) => target.set(
+            &format!("CARGO_TARGET_{}_RUSTFLAGS", coverage_target.to_uppercase().replace('-', "_")),
+            rustflags,
+        ),
+        _ => target.set("RUSTFLAGS", rustflags),
+    }
+
     if let Some(rustdocflags) = rustdocflags {
         target.set("RUSTDOCFLAGS", rustdocflags);
     }

--- a/tests/long-help.txt
+++ b/tests/long-help.txt
@@ -180,6 +180,13 @@ OPTIONS:
             When this option is used, coverage for proc-macro and build script will not be displayed
             because cargo does not pass RUSTFLAGS to them.
 
+        --coverage-target-only
+            Activate coverage reporting only for the target triple
+
+            Activate coverage reporting only for the target triple specified via `--target`. This is
+            important, if the project uses multiple targets via the cargo bindeps feature, and not
+            all targets can use `instrument-coverage`, e.g. a microkernel, or an embedded binary.
+
     -v, --verbose
             Use verbose output
 

--- a/tests/short-help.txt
+++ b/tests/short-help.txt
@@ -137,6 +137,9 @@ OPTIONS:
         --target <TRIPLE>
             Build for the target triple
 
+        --coverage-target-only
+            Activate coverage reporting only for the target triple
+
     -v, --verbose
             Use verbose output
 


### PR DESCRIPTION
Use `CARGO_TARGET_{target}_RUSTFLAGS` rather than `RUSTFLAGS`,
if `--target <TRIPLE>` and `--coverage-target-only` is specified.

This is important, if the project uses multiple targets via the cargo
`bindeps` feature, and not all targets can use `instrument-coverage`,
e.g. a microkernel, or an embedded binary.

Signed-off-by: Harald Hoyer <harald@profian.com>