### PR TITLE
Add --fail-uncovered-{lines,regions,functions} options

### DIFF
--- a/README.md
+++ b/README.md
@@ -130,6 +130,15 @@ OPTIONS:
         --fail-under-lines <MIN>
             Exit with a status of 1 if the total line coverage is less than MIN percent
 
+        --fail-uncovered-lines <MAX>
+            Exit with a status of 1 if the uncovered lines are greater than MAX
+
+        --fail-uncovered-regions <MAX>
+            Exit with a status of 1 if the uncovered regions are greater than MAX
+
+        --fail-uncovered-functions <MAX>
+            Exit with a status of 1 if the uncovered functions are greater than MAX
+
         --show-missing-lines
             Show lines with no coverage
 

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -319,6 +319,15 @@ pub(crate) struct LlvmCovOptions {
     /// Exit with a status of 1 if the total line coverage is less than MIN percent.
     #[clap(long, value_name = "MIN")]
     pub(crate) fail_under_lines: Option<f64>,
+    /// Exit with a status of 1 if the uncovered lines are greater than MAX.
+    #[clap(long, value_name = "MAX")]
+    pub(crate) fail_uncovered_lines: Option<u64>,
+    /// Exit with a status of 1 if the uncovered regions are greater than MAX.
+    #[clap(long, value_name = "MAX")]
+    pub(crate) fail_uncovered_regions: Option<u64>,
+    /// Exit with a status of 1 if the uncovered functions are greater than MAX.
+    #[clap(long, value_name = "MAX")]
+    pub(crate) fail_uncovered_functions: Option<u64>,
     /// Show lines with no coverage.
     #[clap(long)]
     pub(crate) show_missing_lines: bool,

--- a/src/main.rs
+++ b/src/main.rs
@@ -22,7 +22,6 @@ mod context;
 mod demangler;
 mod env;
 mod fs;
-mod json;
 
 use std::{
     collections::HashMap,
@@ -34,6 +33,7 @@ use std::{
 
 use anyhow::{Context as _, Result};
 use camino::{Utf8Path, Utf8PathBuf};
+use cargo_llvm_cov::json;
 use clap::Parser;
 use cli::{RunOptions, ShowEnvOptions};
 use regex::Regex;
@@ -366,7 +366,12 @@ fn generate_report(cx: &Context) -> Result<()> {
             .context("failed to generate report")?;
     }
 
-    if cx.cov.fail_under_lines.is_some() || cx.cov.show_missing_lines {
+    if cx.cov.fail_under_lines.is_some()
+        || cx.cov.fail_uncovered_functions.is_some()
+        || cx.cov.fail_uncovered_lines.is_some()
+        || cx.cov.fail_uncovered_regions.is_some()
+        || cx.cov.show_missing_lines
+    {
         let format = Format::Json;
         let json = format
             .get_json(cx, &object_files, ignore_filename_regex.as_ref())
@@ -376,6 +381,31 @@ fn generate_report(cx: &Context) -> Result<()> {
             // Handle --fail-under-lines.
             let lines_percent = json.get_lines_percent().context("failed to get line coverage")?;
             if lines_percent < fail_under_lines {
+                term::error::set(true);
+            }
+        }
+
+        if let Some(fail_uncovered_functions) = cx.cov.fail_uncovered_functions {
+            // Handle --fail-uncovered-functions.
+            let uncovered =
+                json.count_uncovered_functions().context("failed to count uncovered functions")?;
+            if uncovered > fail_uncovered_functions {
+                term::error::set(true);
+            }
+        }
+        if let Some(fail_uncovered_lines) = cx.cov.fail_uncovered_lines {
+            // Handle --fail-uncovered-lines.
+            let uncovered =
+                json.count_uncovered_lines().context("failed to count uncovered lines")?;
+            if uncovered > fail_uncovered_lines {
+                term::error::set(true);
+            }
+        }
+        if let Some(fail_uncovered_regions) = cx.cov.fail_uncovered_regions {
+            // Handle --fail-uncovered-regions.
+            let uncovered =
+                json.count_uncovered_regions().context("failed to count uncovered regions")?;
+            if uncovered > fail_uncovered_regions {
                 term::error::set(true);
             }
         }

--- a/tests/long-help.txt
+++ b/tests/long-help.txt
@@ -89,6 +89,15 @@ OPTIONS:
         --fail-under-lines <MIN>
             Exit with a status of 1 if the total line coverage is less than MIN percent
 
+        --fail-uncovered-lines <MAX>
+            Exit with a status of 1 if the uncovered lines are greater than MAX
+
+        --fail-uncovered-regions <MAX>
+            Exit with a status of 1 if the uncovered regions are greater than MAX
+
+        --fail-uncovered-functions <MAX>
+            Exit with a status of 1 if the uncovered functions are greater than MAX
+
         --show-missing-lines
             Show lines with no coverage
 

--- a/tests/short-help.txt
+++ b/tests/short-help.txt
@@ -57,6 +57,15 @@ OPTIONS:
         --fail-under-lines <MIN>
             Exit with a status of 1 if the total line coverage is less than MIN percent
 
+        --fail-uncovered-lines <MAX>
+            Exit with a status of 1 if the uncovered lines are greater than MAX
+
+        --fail-uncovered-regions <MAX>
+            Exit with a status of 1 if the uncovered regions are greater than MAX
+
+        --fail-uncovered-functions <MAX>
+            Exit with a status of 1 if the uncovered functions are greater than MAX
+
         --show-missing-lines
             Show lines with no coverage
 


### PR DESCRIPTION
```
        --fail-uncovered-lines <MAX>
            Exit with a status of 1 if the uncovered lines are greater than MAX

        --fail-uncovered-regions <MAX>
            Exit with a status of 1 if the uncovered regions are greater than MAX

        --fail-uncovered-functions <MAX>
            Exit with a status of 1 if the uncovered functions are greater than MAX
```

There is no `--fail-uncovered-branches` option because branch coverage is not supported yet by rustc (#8).

Closes #170 