### PR TITLE
Add --ignore-run-fail option

### DIFF
--- a/README.md
+++ b/README.md
@@ -148,6 +148,11 @@ OPTIONS:
         --no-fail-fast
             Run all tests regardless of failure
 
+        --ignore-run-fail
+            Run all tests regardless of failure and generate report
+
+            If tests failed but report generation succeeded, exit with a status of 0.
+
     -q, --quiet
             Display one character per test instead of one line
 

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -56,6 +56,15 @@ pub(crate) struct Args {
     /// Run all tests regardless of failure
     #[clap(long)]
     pub(crate) no_fail_fast: bool,
+    /// Run all tests regardless of failure and generate report
+    ///
+    /// If tests failed but report generation succeeded, exit with a status of 0.
+    #[clap(
+        long,
+        // --ignore-run-fail implicitly enable --no-fail-fast.
+        conflicts_with = "no-fail-fast",
+    )]
+    pub(crate) ignore_run_fail: bool,
     /// Display one character per test instead of one line
     #[clap(short, long, conflicts_with = "verbose")]
     pub(crate) quiet: bool,

--- a/src/process.rs
+++ b/src/process.rs
@@ -23,6 +23,7 @@ macro_rules! cmd {
 
 // A builder for an external process, inspired by https://github.com/rust-lang/cargo/blob/0.47.0/src/cargo/util/process_builder.rs
 #[must_use]
+#[derive(Clone)]
 pub(crate) struct ProcessBuilder {
     /// The program to execute.
     program: OsString,

--- a/tests/long-help.txt
+++ b/tests/long-help.txt
@@ -107,6 +107,11 @@ OPTIONS:
         --no-fail-fast
             Run all tests regardless of failure
 
+        --ignore-run-fail
+            Run all tests regardless of failure and generate report
+
+            If tests failed but report generation succeeded, exit with a status of 0.
+
     -q, --quiet
             Display one character per test instead of one line
 

--- a/tests/short-help.txt
+++ b/tests/short-help.txt
@@ -72,6 +72,9 @@ OPTIONS:
         --no-fail-fast
             Run all tests regardless of failure
 
+        --ignore-run-fail
+            Run all tests regardless of failure and generate report
+
     -q, --quiet
             Display one character per test instead of one line
 


### PR DESCRIPTION
```
        --ignore-run-fail
            Run all tests regardless of failure and generate report

            If tests failed but report generation succeeded, exit with a status of 0.
```

Closes #169 