### PR TITLE
Add metadata for cargo bininstall

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,6 +15,11 @@ Cargo subcommand to easily use LLVM source-based code coverage (-C instrument-co
 [package.metadata.docs.rs]
 targets = ["x86_64-unknown-linux-gnu"]
 
+[package.metadata.binstall]
+pkg-url = "{ repo }/releases/download/v{ version }/{ name }-{ target }.{ archive-format }"
+bin-dir = "{ bin }{ binary-ext }"
+pkg-fmt = "tar.gz"
+
 [workspace]
 resolver = "2"
 


### PR DESCRIPTION
In contrast with the default documented at
<https://github.com/ryankurte/cargo-binstall#supporting-binary-installation>:

- our pkg-url doesn't contain a version
- bin-dir is just the executable without a parent directory
- pkg-fmt is tar.gz, not tgz

Fixes <https://github.com/taiki-e/cargo-llvm-cov/issues/168>.