### PR TITLE
Improve example workflow steps in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -424,9 +424,9 @@ jobs:
       - name: Install cargo-llvm-cov
         uses: taiki-e/install-action@cargo-llvm-cov
       - name: Generate code coverage
-        run: cargo llvm-cov --all-features --workspace --lcov --output-path lcov.info
+        run: cargo llvm-cov --all-features --workspace --lcov --output-path lcov.info --color always
       - name: Upload coverage to Codecov
-        uses: codecov/codecov-action@v1
+        uses: codecov/codecov-action@v3
         with:
           token: ${{ secrets.CODECOV_TOKEN }} # not required for public repos
           files: lcov.info

--- a/README.md
+++ b/README.md
@@ -417,6 +417,8 @@ on: [pull_request, push]
 jobs:
   coverage:
     runs-on: ubuntu-latest
+    env:
+      CARGO_TERM_COLOR: always
     steps:
       - uses: actions/checkout@v3
       - name: Install Rust
@@ -424,7 +426,7 @@ jobs:
       - name: Install cargo-llvm-cov
         uses: taiki-e/install-action@cargo-llvm-cov
       - name: Generate code coverage
-        run: cargo llvm-cov --all-features --workspace --lcov --output-path lcov.info --color always
+        run: cargo llvm-cov --all-features --workspace --lcov --output-path lcov.info
       - name: Upload coverage to Codecov
         uses: codecov/codecov-action@v3
         with:


### PR DESCRIPTION
- `--color always` is necessary to enable colorful outputs on GitHub Actions. Otherwise colors are not reflected [like this](https://github.com/rhysd/hgrep/runs/6687258213?check_suite_focus=true#step:6:1).
- `codecov-action@v3` is the latest version at this point. In general, using the latest version in example is better because many people copy and paste the example code. I confirmed this upgrade did not break the example.