### PR TITLE
Pin clap to ~3.1

### DIFF
--- a/.clippy.toml
+++ b/.clippy.toml
@@ -1,4 +1,4 @@
-msrv = "1.54"
+msrv = "1.56"
 disallowed-methods = [
     # https://internals.rust-lang.org/t/synchronized-ffi-access-to-posix-environment-variable-functions/15475
     { path = "std::env::remove_var", reason = "this function should be considered `unsafe`" },

--- a/.rustfmt.toml
+++ b/.rustfmt.toml
@@ -26,7 +26,7 @@ use_try_shorthand = true
 
 # Set the default settings again to always apply the proper formatting without
 # being affected by the editor settings.
-edition = "2018"
+edition = "2021"
 hard_tabs = false
 newline_style = "Unix"
 tab_spaces = 4

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "cargo-llvm-cov"
 version = "0.4.6" #publish:version
-edition = "2018"
+edition = "2021"
 rust-version = "1.56"
 license = "Apache-2.0 OR MIT"
 repository = "https://github.com/taiki-e/cargo-llvm-cov"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -28,7 +28,7 @@ anyhow = "1.0.34"
 atty = "0.2.11"
 camino = "1.0.3"
 cargo_metadata = "0.14"
-clap = { version = "3.1", features = ["derive"] }
+clap = { version = "~3.1", features = ["derive"] } # https://github.com/clap-rs/clap/issues/3822
 duct = "0.13.1"
 fs-err = "2.5"
 glob = "0.3"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,7 +2,7 @@
 name = "cargo-llvm-cov"
 version = "0.4.6" #publish:version
 edition = "2018"
-rust-version = "1.54"
+rust-version = "1.56"
 license = "Apache-2.0 OR MIT"
 repository = "https://github.com/taiki-e/cargo-llvm-cov"
 keywords = ["cargo", "coverage", "subcommand", "testing"]

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 [![crates.io](https://img.shields.io/crates/v/cargo-llvm-cov?style=flat-square&logo=rust)](https://crates.io/crates/cargo-llvm-cov)
 [![license](https://img.shields.io/badge/license-Apache--2.0_OR_MIT-blue?style=flat-square)](#license)
-[![rustc](https://img.shields.io/badge/rustc-1.54+-blue?style=flat-square&logo=rust)](https://www.rust-lang.org)
+[![rustc](https://img.shields.io/badge/rustc-1.56+-blue?style=flat-square&logo=rust)](https://www.rust-lang.org)
 [![build status](https://img.shields.io/github/workflow/status/taiki-e/cargo-llvm-cov/CI/main?style=flat-square&logo=github)](https://github.com/taiki-e/cargo-llvm-cov/actions)
 
 Cargo subcommand to easily use LLVM source-based code coverage.
@@ -457,7 +457,7 @@ Running cargo-llvm-cov requires rustc 1.60+.
 cargo install cargo-llvm-cov
 ```
 
-Currently, installing cargo-llvm-cov requires rustc 1.54+.
+Currently, installing cargo-llvm-cov requires rustc 1.56+.
 
 <!-- omit in toc -->
 ### From prebuilt binaries

--- a/src/main.rs
+++ b/src/main.rs
@@ -25,7 +25,6 @@ mod fs;
 
 use std::{
     collections::HashMap,
-    convert::TryInto,
     ffi::{OsStr, OsString},
     fmt::Write as _,
     path::Path,

--- a/tests/auxiliary/mod.rs
+++ b/tests/auxiliary/mod.rs
@@ -1,5 +1,4 @@
 use std::{
-    convert::TryInto,
     env,
     ffi::OsStr,
     io::{Read, Seek, Write},

--- a/tests/fixtures/crates/coverage_helper/Cargo.toml
+++ b/tests/fixtures/crates/coverage_helper/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "no_coverage_coverage_helper"
 version = "0.0.0"
-edition = "2018"
+edition = "2021"
 
 [workspace]
 


### PR DESCRIPTION
Derive macro receives a lot of deprecated warnings.

Refs: https://github.com/clap-rs/clap/issues/3822