### PR TITLE
Escape regular expressions passed to `-ignore-filename-regex`

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -818,14 +818,8 @@ fn ignore_filename_regex(cx: &Context) -> Option<String> {
         }
 
         fn push_abs_path(&mut self, path: impl AsRef<Path>) {
-            #[cfg(not(windows))]
-            let mut path = format!("^{}", path.as_ref().display());
-            #[cfg(windows)]
-            let mut path = format!(
-                "^{}",
-                path.as_ref().to_string_lossy().replace(std::path::MAIN_SEPARATOR, SEPARATOR),
-            );
-            let _ = write!(path, "($|{})", SEPARATOR);
+            let path = regex::escape(path.as_ref().to_string_lossy().as_ref());
+            let path = format!("^{}($|{})", path, SEPARATOR);
             self.push(path);
         }
     }


### PR DESCRIPTION
I noticed some regular expressions passed to `-ignore-filename-regex` in `llvm-cov` command line arguments are not escaped. For example,

```
-ignore-filename-regex '(^|/)(rustc/[0-9a-f]+|tests|examples|benches)/|^/Users/rhysd/Develop/github.com/rhysd/tui-textarea/target/llvm-cov-target($|/)|^/Users/rhysd/.cargo($|/)|^/Users/rhysd/.rustup($|/)'
```

`.` in the expression should be escaped. Otherwise it matches to any character.

This PR fixes the issue by using [`regex::escape`](https://docs.rs/regex/latest/regex/fn.escape.html). This correctly escapes all special characters in regular expressions including the path separator on Windows.