### PR TITLE
Support coverage of C/C++ code linked to Rust library/binary

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,8 @@ Note: In this file, do not use the hard wrap in the middle of a sentence for com
 
 ## [Unreleased]
 
+- Support coverage of C/C++ code linked to Rust library/binary.
+
 ## [0.4.9] - 2022-07-07
 
 - Fix an issue where some files were incorrectly ignored in reports. ([#191](https://github.com/taiki-e/cargo-llvm-cov/pull/191))

--- a/README.md
+++ b/README.md
@@ -264,6 +264,12 @@ OPTIONS:
 
             Note that this does not fully compatible with doctest.
 
+        --include-ffi
+            Include coverage of C/C++ code linked to Rust library/binary
+
+            Note that `CC`/`CXX`/`LLVM_COV`/`LLVM_PROFDATA` environment variables must be set to
+            Clang/LLVM compatible with the LLVM version used in rustc.
+
         --manifest-path <PATH>
             Path to Cargo.toml
 
@@ -360,6 +366,18 @@ cargo llvm-cov clean --workspace # remove artifacts that may affect the coverage
 cargo llvm-cov --no-report --features a
 cargo llvm-cov --no-report --features b
 cargo llvm-cov --no-run --lcov # generate report without tests
+```
+
+### Get coverage of C/C++ code linked to Rust library/binary
+
+Set `CC`, `CXX`, `LLVM_COV`, and `LLVM_PROFDATA` environment variables to Clang/LLVM compatible with the LLVM version used in rustc, and run cargo-llvm-cov with `--include-ffi` flag.
+
+```sh
+CC=<clang-path> \
+CXX=<clang++-path> \
+LLVM_COV=<llvm-cov-path> \
+LLVM_PROFDATA=<llvm-profdata-path> \
+  cargo llvm-cov --lcov --include-ffi
 ```
 
 ### Get coverage of external tests

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -407,6 +407,13 @@ pub(crate) struct BuildOptions {
     /// Note that this does not fully compatible with doctest.
     #[clap(long)]
     pub(crate) remap_path_prefix: bool,
+    /// Include coverage of C/C++ code linked to Rust library/binary
+    ///
+    /// Note that `CC`/`CXX`/`LLVM_COV`/`LLVM_PROFDATA` environment variables
+    /// must be set to Clang/LLVM compatible with the LLVM version used in rustc.
+    // TODO: support specifying languages like: --include-ffi=c,  --include-ffi=c,c++
+    #[clap(long)]
+    pub(crate) include_ffi: bool,
 }
 
 impl BuildOptions {

--- a/src/main.rs
+++ b/src/main.rs
@@ -291,6 +291,17 @@ fn set_env(cx: &Context, target: &mut impl EnvTarget) {
     if let Some(rustdocflags) = rustdocflags {
         target.set("RUSTDOCFLAGS", rustdocflags);
     }
+    if cx.build.include_ffi {
+        let clang_flags = "-fprofile-instr-generate -fcoverage-mapping";
+        if let Some(build_target) = &cx.build.target {
+            let target_lower = build_target.replace('.', "_").replace('-', "_");
+            target.set(&format!("CFLAGS_{}", target_lower), clang_flags);
+            target.set(&format!("CXXFLAGS_{}", target_lower), clang_flags);
+        } else {
+            target.set("CFLAGS", clang_flags);
+            target.set("CXXFLAGS", clang_flags);
+        }
+    }
     target.set("LLVM_PROFILE_FILE", llvm_profile_file.as_str());
     target.set("CARGO_INCREMENTAL", "0");
     // Workaround for https://github.com/rust-lang/rust/issues/91092

--- a/tests/fixtures/crates/ffi/Cargo.toml
+++ b/tests/fixtures/crates/ffi/Cargo.toml
@@ -1,0 +1,10 @@
+[package]
+name = "ffi"
+version = "0.0.0"
+edition = "2021"
+publish = false
+
+[workspace]
+
+[build-dependencies]
+cc = "1"

--- a/tests/fixtures/crates/ffi/build.rs
+++ b/tests/fixtures/crates/ffi/build.rs
@@ -1,0 +1,4 @@
+fn main() {
+    cc::Build::new().file("hello_c.c").compile("hello_c");
+    cc::Build::new().cpp(true).file("hello_cpp.cpp").compile("libhello_cpp.a");
+}

--- a/tests/fixtures/crates/ffi/hello_c.c
+++ b/tests/fixtures/crates/ffi/hello_c.c
@@ -1,0 +1,5 @@
+#include <stdio.h>
+
+void hello_c() {
+    printf("Hello C from Rust!\n");
+}

--- a/tests/fixtures/crates/ffi/hello_cpp.cpp
+++ b/tests/fixtures/crates/ffi/hello_cpp.cpp
@@ -1,0 +1,5 @@
+#include <iostream>
+
+extern "C" void hello_cpp() {
+    std::cout << "Hello C++ from Rust!" << std::endl;
+}

--- a/tests/fixtures/crates/ffi/src/lib.rs
+++ b/tests/fixtures/crates/ffi/src/lib.rs
@@ -1,0 +1,20 @@
+#![warn(rust_2018_idioms, unsafe_op_in_unsafe_fn)]
+
+extern "C" {
+    fn hello_c();
+    fn hello_cpp();
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test() {
+        println!("Hello Rust!");
+        unsafe {
+            hello_c();
+            hello_cpp();
+        }
+    }
+}

--- a/tests/long-help.txt
+++ b/tests/long-help.txt
@@ -223,6 +223,12 @@ OPTIONS:
 
             Note that this does not fully compatible with doctest.
 
+        --include-ffi
+            Include coverage of C/C++ code linked to Rust library/binary
+
+            Note that `CC`/`CXX`/`LLVM_COV`/`LLVM_PROFDATA` environment variables must be set to
+            Clang/LLVM compatible with the LLVM version used in rustc.
+
         --manifest-path <PATH>
             Path to Cargo.toml
 

--- a/tests/short-help.txt
+++ b/tests/short-help.txt
@@ -168,6 +168,9 @@ OPTIONS:
         --remap-path-prefix
             Use --remap-path-prefix for workspace root
 
+        --include-ffi
+            Include coverage of C/C++ code linked to Rust library/binary
+
         --manifest-path <PATH>
             Path to Cargo.toml
 


### PR DESCRIPTION
Set `CC`, `CXX`, `LLVM_COV`, and `LLVM_PROFDATA` environment variables to Clang/LLVM compatible with the LLVM version used in rustc, and run cargo-llvm-cov with `--include-ffi` flag.

```sh
CC=<clang-path> \
CXX=<clang++-path> \
LLVM_COV=<llvm-cov-path> \
LLVM_PROFDATA=<llvm-profdata-path> \
  cargo llvm-cov --lcov --include-ffi
```

Closes #192