### PR TITLE
Don't emit `codegen-units=1` when `stable_coverage` is set

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -268,12 +268,12 @@ fn set_env(cx: &Context, env: &mut impl EnvTarget) {
         } else {
             // TODO: drop support for `-Z instrument-coverage` in the future major release.
             rustdocflags.push_str(" -Z instrument-coverage");
+            if cfg!(windows) {
+                rustdocflags.push_str(" -C codegen-units=1");
+            }
         }
         let _ =
             write!(rustdocflags, " -Z unstable-options --persist-doctests {}", cx.ws.doctests_dir);
-        if cfg!(windows) {
-            rustdocflags.push_str(" -C codegen-units=1");
-        }
         if !cx.cov.no_cfg_coverage {
             rustdocflags.push_str(" --cfg coverage");
         }


### PR DESCRIPTION
Do the same thing in <https://github.com/taiki-e/cargo-llvm-cov/pull/130/files#diff-42cb6807ad74b3e201c5a7ca98b911c5fa08380e942be6e4ac5807f8377f87fcR204> since https://github.com/rust-lang/rust/issues/85461 is already closed.