### PR TITLE
Fix "File name or extension is too long" error when merging profile data on Windows

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -41,6 +41,7 @@ serde = { version = "1.0.103", features = ["derive"] }
 serde_json = "1"
 shell-escape = "0.1.5"
 target-spec = "1"
+tempfile = "3"
 termcolor = "1.1.2"
 walkdir = "2.2.3"
 
@@ -49,4 +50,3 @@ easy-ext = "1"
 itertools = "0.10"
 once_cell = "1"
 rustversion = "1"
-tempfile = "3"

--- a/src/main.rs
+++ b/src/main.rs
@@ -514,7 +514,9 @@ fn merge_profraw(cx: &Context) -> Result<()> {
             .filter_map(Result::ok);
     let mut input_files = tempfile::NamedTempFile::new()?;
     for path in profraw_files {
-        writeln!(input_files, "{}", path.display())?;
+        let path_str =
+            path.to_str().with_context(|| format!("{:?} contains invalid utf-8 data", path))?;
+        writeln!(input_files, "{}", path_str)?;
     }
     let mut cmd = cx.process(&cx.llvm_profdata);
     cmd.args(["merge", "-sparse"])

--- a/src/main.rs
+++ b/src/main.rs
@@ -28,7 +28,7 @@ use std::{
     collections::HashMap,
     ffi::{OsStr, OsString},
     fmt::Write as _,
-    io,
+    io::{self, Write},
     path::Path,
 };
 
@@ -509,12 +509,17 @@ fn open_report(cx: &Context, path: &Utf8Path) -> Result<()> {
 
 fn merge_profraw(cx: &Context) -> Result<()> {
     // Convert raw profile data.
+    let profraw_files =
+        glob::glob(cx.ws.target_dir.join(format!("{}-*.profraw", cx.ws.name)).as_str())?
+            .filter_map(Result::ok);
+    let mut input_files = tempfile::NamedTempFile::new()?;
+    for path in profraw_files {
+        writeln!(input_files, "{}", path.display())?;
+    }
     let mut cmd = cx.process(&cx.llvm_profdata);
     cmd.args(["merge", "-sparse"])
-        .args(
-            glob::glob(cx.ws.target_dir.join(format!("{}-*.profraw", cx.ws.name)).as_str())?
-                .filter_map(Result::ok),
-        )
+        .arg("-f")
+        .arg(input_files.path())
         .arg("-o")
         .arg(&cx.ws.profdata_file);
     if let Some(mode) = &cx.cov.failure_mode {


### PR DESCRIPTION
See https://github.com/PyO3/pyo3/runs/7682300607?check_suite_focus=true

> (never executed): The filename or extension is too long. (os error 206)

Switched to use [`-f`](https://llvm.org/docs/CommandGuide/llvm-profdata.html#cmdoption-llvm-profdata-merge-input-files) to pass input files by a temp file.