### PR TITLE
Do not redirect output from stdout to stderr if unnecessary

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,8 @@ Note: In this file, do not use the hard wrap in the middle of a sentence for com
 
 ## [Unreleased]
 
+- cargo-llvm-cov no longer redirects output from stdout to stderr if unnecessary. ([#206](https://github.com/taiki-e/cargo-llvm-cov/pull/206))
+
 ## [0.4.14] - 2022-08-06
 
 - Fix an issue where "File name or extension is too long" error occurs in Windows. ([#203](https://github.com/taiki-e/cargo-llvm-cov/pull/203), thanks @messense)


### PR DESCRIPTION
Do not redirect output from stdout to stderr when any of `--no-report`, `--output-path`, `--output-dir` is passed.

Fixes #205