### PR TITLE
Improve handling of cases where llvm-tools-preview is not installed

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,16 @@ Note: In this file, do not use the hard wrap in the middle of a sentence for com
 
 ## [Unreleased]
 
+- Improve handling of cases where `llvm-tools-preview` component is not installed. ([#219](https://github.com/taiki-e/cargo-llvm-cov/pull/219))
+
+  **TL;DR:** You no longer need to install `llvm-tools-preview` before running cargo-llvm-cov in most cases.
+
+  Previously, cargo-llvm-cov exit with error suggesting the installation of `llvm-tools-preview`.
+
+  The new logic is based on the logic used by Miri when `rust-src` component or `xargo` is not installed.
+
+  See [#219](https://github.com/taiki-e/cargo-llvm-cov/pull/219) for more.
+
 - Fix various CLI-related bugs. ([#197](https://github.com/taiki-e/cargo-llvm-cov/pull/197))
 
   This fixes various bugs related to subcommands (especially `nextest`). The following is a partial list:

--- a/README.md
+++ b/README.md
@@ -466,7 +466,7 @@ jobs:
     steps:
       - uses: actions/checkout@v3
       - name: Install Rust
-        run: rustup toolchain install stable --component llvm-tools-preview
+        run: rustup update stable
       - name: Install cargo-llvm-cov
         uses: taiki-e/install-action@cargo-llvm-cov
       - name: Generate code coverage
@@ -485,12 +485,6 @@ jobs:
 
 <!-- omit in toc -->
 ### Prerequisites
-
-cargo-llvm-cov requires llvm-tools-preview:
-
-```sh
-rustup component add llvm-tools-preview
-```
 
 Running cargo-llvm-cov requires rustc 1.60+.
 


### PR DESCRIPTION
**TL;DR:** You no longer need to install `llvm-tools-preview` before running cargo-llvm-cov in most cases.

Previously, cargo-llvm-cov exit with error suggesting the installation of `llvm-tools-preview`.

The new logic is based on the logic used by Miri when `rust-src` component or `xargo` is not installed.

- cargo-llvm-cov asks the user if they want to install the `llvm-tools-preview`, and if the user allows it, cargo-llvm-cov will install the `llvm-tools-preview`.
- On CI, cargo-llvm-cov will install the `llvm-tools-preview` without asking the user (interactive prompts don't work on CI).

Additionally, this adds an environment variable to control the behavior here.

- If `CARGO_LLVM_COV_SETUP=no` environment variable is set, cargo-llvm-cov exit with error suggesting the installation of `llvm-tools-preview`. This matches with the previous behavior.
- If `CARGO_LLVM_COV_SETUP=yes` environment variable is set, cargo-llvm-cov will install the `llvm-tools-preview` without asking the user. This matches with the behavior on CI.
