### PR TITLE
Cobertura support

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -44,6 +44,7 @@ target-spec = "1.1"
 tempfile = "3"
 termcolor = "1.1.2"
 walkdir = "2.2.3"
+lcov2cobertura = "1.0.0"
 
 [dev-dependencies]
 easy-ext = "1"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -44,7 +44,7 @@ target-spec = "1.1"
 tempfile = "3"
 termcolor = "1.1.2"
 walkdir = "2.2.3"
-lcov2cobertura = "1.0.0"
+lcov2cobertura = "1.0.1"
 
 [dev-dependencies]
 easy-ext = "1"

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -206,6 +206,7 @@ impl Args {
         // llvm-cov options
         let mut json = false;
         let mut lcov = false;
+        let mut cobertura = false;
         let mut text = false;
         let mut html = false;
         let mut open = false;
@@ -362,6 +363,7 @@ impl Args {
                 // report options
                 Long("json") => parse_flag!(json),
                 Long("lcov") => parse_flag!(lcov),
+                Long("cobertura") => parse_flag!(cobertura),
                 Long("text") => parse_flag!(text),
                 Long("html") => parse_flag!(html),
                 Long("open") => parse_flag!(open),
@@ -640,6 +642,12 @@ impl Args {
                 conflicts(flag, "--json")?;
             }
         }
+        if cobertura {
+            let flag = "--cobertura";
+            if json {
+                conflicts(flag, "--json")?;
+            }
+        }
         if text {
             let flag = "--text";
             if json {
@@ -724,6 +732,7 @@ impl Args {
             cov: LlvmCovOptions {
                 json,
                 lcov,
+                cobertura,
                 text,
                 html,
                 open,
@@ -878,6 +887,14 @@ pub(crate) struct LlvmCovOptions {
     /// This internally calls `llvm-cov export -format=lcov`.
     /// See <https://llvm.org/docs/CommandGuide/llvm-cov.html#llvm-cov-export> for more.
     pub(crate) lcov: bool,
+
+    /// Export coverage data in "cobertura" XML format
+    ///
+    /// If --output-path is not specified, the report will be printed to stdout.
+    ///
+    /// This internally calls `llvm-cov export -format=lcov` and then converts to cobertura.xml
+    /// See <https://llvm.org/docs/CommandGuide/llvm-cov.html#llvm-cov-export> for more.
+    pub(crate) cobertura: bool,
 
     /// Generate coverage report in “text” format
     ///

--- a/src/main.rs
+++ b/src/main.rs
@@ -696,6 +696,8 @@ enum Format {
     Json,
     /// `llvm-cov export -format=lcov`
     LCov,
+    /// `llvm-cov export -format=lcov` later converted to XML
+    Cobertura,
     /// `llvm-cov show -format=text`
     Text,
     /// `llvm-cov show -format=html`
@@ -708,6 +710,8 @@ impl Format {
             Self::Json
         } else if cx.args.cov.lcov {
             Self::LCov
+        } else if cx.args.cov.cobertura {
+            Self::Cobertura
         } else if cx.args.cov.text {
             Self::Text
         } else if cx.args.cov.html {
@@ -722,6 +726,7 @@ impl Format {
             Self::None => &["report"],
             Self::Json => &["export", "-format=text"],
             Self::LCov => &["export", "-format=lcov"],
+            Self::Cobertura => &["export", "-format=lcov"],
             Self::Text => &["show", "-format=text"],
             Self::Html => &["show", "-format=html"],
         }
@@ -778,7 +783,7 @@ impl Format {
                     }
                 }
             }
-            Self::Json | Self::LCov => {
+            Self::Json | Self::LCov | Self::Cobertura => {
                 if cx.args.cov.summary_only {
                     cmd.arg("-summary-only");
                 }
@@ -798,6 +803,28 @@ impl Format {
             fs::write(output_path, out)?;
             eprintln!();
             status!("Finished", "report saved to {output_path}");
+            return Ok(());
+        }
+
+        if cx.args.cov.cobertura {
+            use std::io::BufRead;
+            if term::verbose() {
+                status!("Running", "{cmd}");
+            }
+            let lcov = cmd.read()?;
+            // Convert to XML
+            let cdata = lcov2cobertura::parse_lines(lcov.as_bytes().lines(), "", &[])?;
+            let demangler = lcov2cobertura::RustDemangler::new();
+            let out = lcov2cobertura::coverage_to_string(&cdata, 1_346_815_648_000, demangler)?;
+
+            if let Some(output_path) = &cx.args.cov.output_path {
+                fs::write(output_path, out)?;
+                eprintln!();
+                status!("Finished", "report saved to {output_path}");
+            } else {
+                // write XML to stdout
+                println!("{}", out);
+            }
             return Ok(());
         }
 


### PR DESCRIPTION
for issue #106 using my crate as described in the issue.

Output numbers look the same as the python script, and output validates against `coverage-04.dtd` however this needs testing by people that use cobertura for longer than me.

e.g. I got distracted writing a XML splitter too (hence the delay for this PR), since that seems to be a needed feature for GitLab and large codebases. While testing it I found out that people splitting those XML files assume an invalid cobertura input file in the first place (DTD wouldn't validate). Spooky stuff that cobertura ecosystem 🤷 

if my patch is too wild or hacky, no worries I can make a new clean PR with a proper integration, just let me know. however: 
this works for me ™️ 😋 