### PR TITLE
Output cobertura data before bailing out

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -801,17 +801,6 @@ impl Format {
             cmd.args(flags.split(' ').filter(|s| !s.trim().is_empty()));
         }
 
-        if let Some(output_path) = &cx.args.cov.output_path {
-            if term::verbose() {
-                status!("Running", "{cmd}");
-            }
-            let out = cmd.read()?;
-            fs::write(output_path, out)?;
-            eprintln!();
-            status!("Finished", "report saved to {output_path}");
-            return Ok(());
-        }
-
         if cx.args.cov.cobertura {
             if term::verbose() {
                 status!("Running", "{cmd}");
@@ -834,6 +823,17 @@ impl Format {
                 // write XML to stdout
                 println!("{out}");
             }
+            return Ok(());
+        }
+
+        if let Some(output_path) = &cx.args.cov.output_path {
+            if term::verbose() {
+                status!("Running", "{cmd}");
+            }
+            let out = cmd.read()?;
+            fs::write(output_path, out)?;
+            eprintln!();
+            status!("Finished", "report saved to {output_path}");
             return Ok(());
         }
 


### PR DESCRIPTION
This fixes an issue where if `--cobertura` and `--output-path` are used simultaneously, then the saved file doesn't contain the cobertura-style output because the code returns inside `if let Some(output_path) = &cx.args.cov.output_path` and doesn't enter the cobertura clause at all.