### PR TITLE
Doctest experiment 2

### DIFF
--- a/src/json.rs
+++ b/src/json.rs
@@ -29,6 +29,22 @@ impl LlvmCovJsonExport {
         }
     }
 
+    #[must_use]
+    pub fn function_names(&self, filter: impl Fn(&str) -> bool) -> Vec<&str> {
+        let mut v = vec![];
+        for data in &self.data {
+            if let Some(functions) = data.functions.as_ref().filter(|f| !f.is_empty()) {
+                v.reserve(functions.len() / 2);
+                for func in functions {
+                    if filter(&func.name) {
+                        v.push(&*func.name);
+                    }
+                }
+            }
+        }
+        v
+    }
+
     /// Gets the minimal lines coverage of all files.
     pub fn get_lines_percent(&self) -> Result<f64> {
         let mut count = 0_f64;


### PR DESCRIPTION
Experiment for https://github.com/taiki-e/cargo-llvm-cov/issues/123.

This uses [-name-allowlist](https://llvm.org/docs/CommandGuide/llvm-cov.html#cmdoption-llvm-cov-show-name-allowlist) option. It allows to remove doc examples from html/text reports but only shows functions and the order of the code is messed up.