### PR TITLE
detect dev builds by channel not version

### DIFF
--- a/src/cargo.rs
+++ b/src/cargo.rs
@@ -146,7 +146,7 @@ fn rustc_version(rustc: &ProcessBuilder) -> Result<bool> {
         .find_map(|line| line.strip_prefix("release: "))
         .ok_or_else(|| format_err!("unexpected version output from `{cmd}`: {verbose_version}"))?;
     let (_version, channel) = version.split_once('-').unwrap_or_default();
-    let nightly = channel == "nightly" || channel == "dev" || version == "dev";
+    let nightly = channel == "nightly" || channel == "dev";
     Ok(nightly)
 }
 

--- a/src/cargo.rs
+++ b/src/cargo.rs
@@ -146,7 +146,7 @@ fn rustc_version(rustc: &ProcessBuilder) -> Result<bool> {
         .find_map(|line| line.strip_prefix("release: "))
         .ok_or_else(|| format_err!("unexpected version output from `{cmd}`: {verbose_version}"))?;
     let (_version, channel) = version.split_once('-').unwrap_or_default();
-    let nightly = channel == "nightly" || version == "dev";
+    let nightly = channel == "nightly" || channel == "dev" || version == "dev";
     Ok(nightly)
 }
 


### PR DESCRIPTION
I have a dev build that I'm trying to use with cargo-llvm-cov, I'm trying to use the `--doctests`, and I'm getting the following error:
```
error: --doctests flag requires nightly toolchain; consider using `cargo +nightly llvm-cov`
```
My version is `1.68.2-dev` - this PR updates llvm-cov to detect dev versions via the channel suffix "dev". 

(I presumed that the entire version string being "dev" was correct, so left the existing "version == dev" check)

