### PR TITLE
Set CARGO_LLVM_COV environment variable

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -290,6 +290,7 @@ fn set_env(cx: &Context, env: &mut dyn EnvTarget, IsNextest(is_nextest): IsNexte
         // Same as above
         env.set("NEXTEST_TEST_THREADS", "1")?;
     }
+    env.set("CARGO_LLVM_COV", "1")?;
     Ok(())
 }
 


### PR DESCRIPTION
So that nextest can detect if it's running wrapped by "cargo llvm-cov" and can use [profile.default-llvm-cov] settings instead of [profile.default]. This is done similarly for miri and makes sense since both increase running times.