### PR TITLE
Use llvm-args instead of RUST_TEST_THREADS, %Nm instead of NEXTEST_TEST_THREADS

### DIFF
--- a/.github/.cspell/project-dictionary.txt
+++ b/.github/.cspell/project-dictionary.txt
@@ -6,6 +6,7 @@ doctestbins
 easytime
 fcoverage
 fprofile
+instrprof
 libdir
 libhello
 microkernel

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,9 @@ Note: In this file, do not use the hard wrap in the middle of a sentence for com
 
 ## [Unreleased]
 
-- cargo-llvm-cov no longer sets the `RUST_TEST_THREADS` environment variable and uses llvm-args instead for workaround [rust-lang/rust#91092](https://github.com/rust-lang/rust/issues/91092).
+- cargo-llvm-cov no longer sets the `RUST_TEST_THREADS` and `NEXTEST_TEST_THREADS` environment variables. cargo-llvm-cov now adopts another efficient way to workaround [rust-lang/rust#91092](https://github.com/rust-lang/rust/issues/91092). ([#279](https://github.com/taiki-e/cargo-llvm-cov/pull/279))
+
+  This may greatly improve performance, [especially when using `cargo llvm-cov nextest`](https://github.com/taiki-e/cargo-llvm-cov/pull/279#issuecomment-1552058044).
 
 ## [0.5.19] - 2023-04-28
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,8 @@ Note: In this file, do not use the hard wrap in the middle of a sentence for com
 
 ## [Unreleased]
 
+- cargo-llvm-cov no longer sets the `RUST_TEST_THREADS` environment variable and uses llvm-args instead for workaround [rust-lang/rust#91092](https://github.com/rust-lang/rust/issues/91092).
+
 ## [0.5.19] - 2023-04-28
 
 - Fix handling of `--cargo-profile` option for `cargo llvm-cov nextest`. ([#269](https://github.com/taiki-e/cargo-llvm-cov/pull/269))

--- a/README.md
+++ b/README.md
@@ -622,7 +622,7 @@ pacman -S cargo-llvm-cov
 
 - Branch coverage is not supported yet. See [#8] and [rust-lang/rust#79649] for more.
 - Support for doc tests is unstable and has known issues. See [#2] and [rust-lang/rust#79417] for more.
-- All the tests are run with `RUST_TEST_THREADS=1` to work around [rust-lang/rust#91092]. You can pass `--test-threads` (e.g., `--test-threads=$(nproc)`) to override this behavior. (As for `nextest`, we also set `NEXTEST_TEST_THREADS=1`.)
+- `cargo llvm-cov nextest` is run with `NEXTEST_TEST_THREADS=1` to work around [rust-lang/rust#91092]. You can pass `--test-threads` (e.g., `--test-threads=$(nproc)`) to override this behavior.
 
 See also [the code-coverage-related issues reported in rust-lang/rust](https://github.com/rust-lang/rust/labels/A-code-coverage).
 

--- a/README.md
+++ b/README.md
@@ -622,7 +622,6 @@ pacman -S cargo-llvm-cov
 
 - Branch coverage is not supported yet. See [#8] and [rust-lang/rust#79649] for more.
 - Support for doc tests is unstable and has known issues. See [#2] and [rust-lang/rust#79417] for more.
-- `cargo llvm-cov nextest` is run with `NEXTEST_TEST_THREADS=1` to work around [rust-lang/rust#91092]. You can pass `--test-threads` (e.g., `--test-threads=$(nproc)`) to override this behavior.
 
 See also [the code-coverage-related issues reported in rust-lang/rust](https://github.com/rust-lang/rust/labels/A-code-coverage).
 
@@ -648,7 +647,6 @@ See also [the code-coverage-related issues reported in rust-lang/rust](https://g
 [rust-lang/rust#79417]: https://github.com/rust-lang/rust/issues/79417
 [rust-lang/rust#79649]: https://github.com/rust-lang/rust/issues/79649
 [rust-lang/rust#84605]: https://github.com/rust-lang/rust/issues/84605
-[rust-lang/rust#91092]: https://github.com/rust-lang/rust/issues/91092
 [xtask]: https://github.com/matklad/cargo-xtask
 
 ## License

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -358,10 +358,10 @@ impl Args {
                 // build options
                 Short('r') | Long("release") => parse_flag_passthrough!(release),
                 Long("profile") if subcommand != Subcommand::Nextest => {
-                    parse_opt_passthrough!(profile)
+                    parse_opt_passthrough!(profile);
                 }
                 Long("cargo-profile") if subcommand == Subcommand::Nextest => {
-                    parse_opt_passthrough!(profile)
+                    parse_opt_passthrough!(profile);
                 }
                 Long("target") => parse_opt_passthrough!(target),
                 Long("coverage-target-only") => parse_flag!(coverage_target_only),


### PR DESCRIPTION
cargo-llvm-cov no longer sets the `RUST_TEST_THREADS` environment variable and uses llvm-args instead for workaround [rust-lang/rust#91092](https://github.com/rust-lang/rust/issues/91092).

TODO: skip passing llvm-args on newer nightly that includes https://github.com/rust-lang/rust/pull/111469.

Closes #258
cc @Dushistov