### PR TITLE
Add %c to LLVM_PROFILE_FILE

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -228,6 +228,16 @@ fn set_env(cx: &Context, env: &mut dyn EnvTarget, IsNextest(is_nextest): IsNexte
     } else {
         llvm_profile_file_name.push_str("-%m");
     }
+    // https://clang.llvm.org/docs/SourceBasedCodeCoverage.html#running-the-instrumented-program
+    if cx.args.target.as_ref().map_or(cfg!(target_os = "macos"), |t| t.contains("-darwin"))
+        || cx
+            .args
+            .target
+            .as_ref()
+            .map_or(cfg!(target_os = "linux"), |t| t.contains("-linux") && !t.contains("-android"))
+    {
+        llvm_profile_file_name.push_str("-%c");
+    }
     llvm_profile_file_name.push_str(".profraw");
     let llvm_profile_file = cx.ws.target_dir.join(llvm_profile_file_name);
 


### PR DESCRIPTION
Refs: https://clang.llvm.org/docs/SourceBasedCodeCoverage.html#running-the-instrumented-program

> “%c” expands out to nothing, but enables a mode in which profile counter updates are continuously synced to a file. This means that if the instrumented program crashes, or is killed by a signal, perfect coverage information can still be recovered. Continuous mode does not support value profiling for PGO, and is only supported on Darwin at the moment. Support for Linux may be mostly complete but requires testing, and support for Windows may require more extensive changes: please get involved if you are interested in porting this feature.


Closes https://github.com/taiki-e/cargo-llvm-cov/issues/235