### PR TITLE
Inject metadata into the llvm-cov JSON output

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,8 @@ Note: In this file, do not use the hard wrap in the middle of a sentence for com
 
 ## [Unreleased]
 
+- Inject additional contextual information about cargo-llvm-cov into the JSON output of llvm-cov. It allows other programs, that rely on this output, to make certain assertions about the behavior of cargo-llvm-cov and can help to share common information.
+
 ## [0.5.20] - 2023-06-02
 
 - cargo-llvm-cov no longer sets the `RUST_TEST_THREADS` and `NEXTEST_TEST_THREADS` environment variables. cargo-llvm-cov now adopts another efficient way to workaround [rust-lang/rust#91092](https://github.com/rust-lang/rust/issues/91092). ([#279](https://github.com/taiki-e/cargo-llvm-cov/pull/279))

--- a/README.md
+++ b/README.md
@@ -25,6 +25,7 @@ This is a wrapper around rustc [`-C instrument-coverage`][instrument-coverage] a
   - [Exclude function from coverage](#exclude-function-from-coverage)
   - [Continuous Integration](#continuous-integration)
   - [Environment variables](#environment-variables)
+  - [Additional JSON information](#additional-json-information)
 - [Installation](#installation)
 - [Known limitations](#known-limitations)
 - [Related Projects](#related-projects)
@@ -527,6 +528,29 @@ You can override these environment variables to change cargo-llvm-cov's behavior
 - `LLVM_PROFDATA_FLAGS` -- A space-separated list of additional flags to pass to all `llvm-profdata` invocations that cargo-llvm-cov performs. See [LLVM documentation](https://llvm.org/docs/CommandGuide/llvm-profdata.html) for available options.
 
 See also [environment variables that Cargo reads](https://doc.rust-lang.org/nightly/cargo/reference/environment-variables.html#environment-variables-cargo-reads). cargo-llvm-cov respects many of them.
+
+### Additional JSON information
+
+If **JSON** is selected as output format (with the `--json` flag), then cargo-llvm-cov will add additional contextual information at the root of the llvm-cov data. This can be helpful for programs that rely on the output of cargo-llvm-cov.
+
+```json
+{
+  // Other regular llvm-cov fields ...
+  "cargo_llvm_cov": {
+    "version": "0.0.0",
+    "manifest_path": "/path/to/your/project/Cargo.toml"
+  }
+}
+```
+
+- `version` specifies the version of cargo-llvm-cov that was used. This allows other programs to verify a certain version of it was used and make assertions of its behavior.
+- `manifest_path` defines the absolute path to the Rust project's Cargo.toml that cargo-llvm-cov was executed on. It can help to avoid repeating the same option on both programs.
+
+For example, when forwarding the JSON output directly to another program:
+
+```sh
+cargo-llvm-cov --json | some-program
+```
 
 ## Installation
 

--- a/src/json.rs
+++ b/src/json.rs
@@ -4,6 +4,7 @@ use std::{
 };
 
 use anyhow::{Context as _, Result};
+use camino::Utf8PathBuf;
 use regex::Regex;
 use serde::{ser::SerializeMap, Deserialize, Serialize, Serializer};
 
@@ -17,6 +18,9 @@ pub struct LlvmCovJsonExport {
     #[serde(rename = "type")]
     pub(crate) type_: String,
     pub(crate) version: String,
+    /// Additional information injected into the export data.
+    #[serde(skip_deserializing, skip_serializing_if = "Option::is_none")]
+    cargo_llvm_cov: Option<CargoLlvmCov>,
 }
 
 /// <https://docs.codecov.com/docs/codecov-custom-coverage-format>
@@ -148,6 +152,11 @@ impl LlvmCovJsonExport {
                 }
             }
         }
+    }
+
+    pub fn inject(&mut self, manifest_path: Utf8PathBuf) {
+        self.cargo_llvm_cov =
+            Some(CargoLlvmCov { version: env!("CARGO_PKG_VERSION"), manifest_path });
     }
 
     /// Gets the minimal lines coverage of all files.
@@ -500,6 +509,17 @@ pub(crate) struct CoverageCounts {
     pub(crate) percent: f64,
 }
 
+/// Information that is not part of the llvm-cov JSON export, but instead injected afterwards by us.
+#[derive(Debug, Default, Serialize)]
+#[cfg_attr(test, derive(PartialEq))]
+struct CargoLlvmCov {
+    /// Version of this project, which allows projects that depend on it, to express and verify
+    /// requirements on specific versions.
+    version: &'static str,
+    /// Resolved path to the `Cargo.toml` manifest.
+    manifest_path: Utf8PathBuf,
+}
+
 #[cfg(test)]
 mod tests {
     use std::path::Path;
@@ -525,6 +545,7 @@ mod tests {
             let json = serde_json::from_str::<LlvmCovJsonExport>(&s).unwrap();
             assert_eq!(json.type_, "llvm.coverage.json.export");
             assert!(json.version.starts_with("2.0."));
+            assert_eq!(json.cargo_llvm_cov, None);
             serde_json::to_string(&json).unwrap();
         }
     }


### PR DESCRIPTION
As discussed in #285, this injects some metadata into the JSON output of `llvm-cov`. This can be helpful for tools that rely on the output of it and `cargo-llvm-cov` as well.

It adds in the following fields under a new `cargo_llvm_cov` field in the root JSON structure:

- `version` is the cargo-llvm-cov version that was invoked. Helpful for tools to verify that cargo-llvm-cov is of a certain version and has some expected behavior.
- `manifest_path` is the location of the Cargo.toml as resolved by cargo-llvm-cov. This is two-fold:
  - It can reduce repetition, as otherwise a custom manifest path would need to specified for both cargo-llvm-cov and the other tool.
  - There might be minor differences in how the mainfest path was resolved, so this ensures the other tool gets exactly the same manifest path as cargo-llvm-cov.


Fixes #285