### PR TITLE
allow nightly to be specified by RUSTC_BOOTSTRAP=1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,8 @@ Note: In this file, do not use the hard wrap in the middle of a sentence for com
 
 ## [Unreleased]
 
+- Fix: Allow nightly to be specified by setting `RUSTC_BOOTSTRAP=1`, the same as for rust and cargo.
+
 ## [0.5.24] - 2023-07-28
 
 - Update `cargo_metadata` to 0.17.

--- a/src/cargo.rs
+++ b/src/cargo.rs
@@ -50,7 +50,7 @@ impl Workspace {
         let target_for_config = target_for_config.pop().unwrap();
         let target_for_cli = config.build_target_for_cli(target)?.pop();
         let rustc = ProcessBuilder::from(config.rustc().clone());
-        let nightly = rustc_version(&rustc)?;
+        let nightly = rustc_version(&rustc)? || rustc_bootstrap()?;
 
         if doctests && !nightly {
             bail!("--doctests flag requires nightly toolchain; consider using `cargo +nightly llvm-cov`")
@@ -157,6 +157,14 @@ fn rustc_version(rustc: &ProcessBuilder) -> Result<bool> {
     let (_version, channel) = version.split_once('-').unwrap_or_default();
     let nightly = channel == "nightly" || channel == "dev";
     Ok(nightly)
+}
+
+fn rustc_bootstrap() -> Result<bool> {
+    if let Some(bootstrap) = env::var("RUSTC_BOOTSTRAP")? {
+        Ok(bootstrap == "1")
+    } else {
+        Ok(false)
+    }
 }
 
 fn package_root(cargo: &OsStr, manifest_path: Option<&Utf8Path>) -> Result<Utf8PathBuf> {


### PR DESCRIPTION
Currently the only way to specify nightly is by having your rustc release version ending in "-nightly" or "-dev". This PR allows the environment variable RUSTC_BOOSTRAP=1 to also specify nightly, in line with cargo and rust.

I have tested this locally and the variable is used as expected.