### PR TITLE
Always handle .dll as object file on Windows

### DIFF
--- a/.github/.cspell/project-dictionary.txt
+++ b/.github/.cspell/project-dictionary.txt
@@ -13,7 +13,6 @@ libhello
 microkernel
 nextest
 notcovered
-OSTYPE
 pacman
 profdata
 profraw

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -93,11 +93,7 @@ jobs:
           # Test trybuild compatibility.
           git clone https://github.com/taiki-e/easy-ext.git
           cd easy-ext
-          case "${OSTYPE}" in
-            # TODO(windows)
-            cygwin* | msys*) cargo llvm-cov --text --test compiletest ;;
-            *) cargo llvm-cov --text --test compiletest --fail-under-lines 70 ;;
-          esac
+          cargo llvm-cov --text --test compiletest --fail-under-lines 70
         if: startsWith(matrix.rust, 'nightly')
       - run: cargo minimal-versions build --workspace --all-features --ignore-private
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -160,7 +160,8 @@ struct ShowEnvWriter<W: io::Write> {
 impl<W: io::Write> EnvTarget for ShowEnvWriter<W> {
     fn set(&mut self, key: &str, value: &str) -> Result<()> {
         let prefix = if self.options.export_prefix { "export " } else { "" };
-        writeln!(self.writer, r#"{prefix}{key}="{value}""#).context("failed to write env to stdout")
+        writeln!(self.writer, "{prefix}{key}={}", shell_escape::escape(value.into()))
+            .context("failed to write env to stdout")
     }
     fn unset(&mut self, key: &str) -> Result<()> {
         if env::var_os(key).is_some() {


### PR DESCRIPTION
Fixes #300

We currently treat files that is_executable crate considers executable as object files. However, the is_executable crate did not consider the DLL files generated as a result of compiling cdylib (or proc-macro) crate to be executable, so those files were not collected as object files.

