### PR TITLE
Invoke llvm-cov show with `-show-branches`

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -897,6 +897,7 @@ impl Format {
                     &format!("-show-instantiations={}", !cx.args.cov.hide_instantiations),
                     "-show-line-counts-or-regions",
                     "-show-expansions",
+                    "-show-branches=count",
                     &format!("-Xdemangler={}", cx.current_exe.display()),
                     "-Xdemangler=llvm-cov",
                     "-Xdemangler=demangle",


### PR DESCRIPTION
The Rust compiler will gain support for Branch Coverage in the future, so add the `-show-branches` flag to `llvm-cov` to take advantage of that support.

See https://github.com/rust-lang/rust/pull/115061 which is an early proof of concept to output branch regions.