### PR TITLE
Fix empty source path generated in cobertura.xml

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -928,7 +928,11 @@ impl Format {
             }
             let lcov = cmd.read()?;
             // Convert to XML
-            let cdata = lcov2cobertura::parse_lines(lcov.as_bytes().lines(), "", &[])?;
+            let cdata = lcov2cobertura::parse_lines(
+                lcov.as_bytes().lines(),
+                &cx.ws.metadata.workspace_root,
+                &[],
+            )?;
             let demangler = lcov2cobertura::RustDemangler::new();
             let now = SystemTime::now()
                 .duration_since(SystemTime::UNIX_EPOCH)


### PR DESCRIPTION
Currently `cobertura.xml` is generated with empty path in `<source></source>` which lead to full path being used in `filename` attributes:
<details>
 <summary>`cobertura.xml` as produced but current `llvm-cov report --cobertura`</summary>

```xml
<?xml version="1.0" ?>
<!DOCTYPE coverage SYSTEM "https://cobertura.sourceforge.net/xml/coverage-04.dtd">
<coverage branch-rate="0" branches-covered="0" branches-valid="0" complexity="0" line-rate="0.4838709677419355" lines-covered="15" lines-valid="31" timestamp="1692890446" version="2.0.3">
    <sources>
        <source></source>
    </sources>
    <packages>
        <package line-rate="0.4838709677419355" branch-rate="0" name=".test-ci.src" complexity="0">
            <classes>
                <class branch-rate="0" complexity="0" filename="/test-ci/src/lib.rs" line-rate="0.5769230769230769" name=".test-ci.src.lib.rs">
                    <methods>
                        <method name="test_ci::tests::test_bad_sum::{closure#0}" signature="" complexity="0" line-rate="1" branch-rate="1">
                            <lines>
                                <line hits="1" number="34" branch="false"/>
                            </lines>
                        </method>
                        <method name="test_ci::tests::test_success::{closure#0}" signature="" complexity="0" line-rate="1" branch-rate="1">
                            <lines>
                                <line hits="1" number="24" branch="false"/>
                            </lines>
                        </method>
                        <method name="test_ci::uncovered_sum" signature="" complexity="0" line-rate="0" branch-rate="0">
                            <lines>
                                <line hits="0" number="9" branch="false"/>
                            </lines>
                        </method>
                        <method name="test_ci::covered_bad_sum" signature="" complexity="0" line-rate="1" branch-rate="1">
                            <lines>
                                <line hits="1" number="13" branch="false"/>
                            </lines>
                        </method>
                        <method name="test_ci::run" signature="" complexity="0" line-rate="0" branch-rate="0">
                            <lines>
                                <line hits="0" number="1" branch="false"/>
                            </lines>
                        </method>
                        <method name="test_ci::two" signature="" complexity="0" line-rate="0" branch-rate="0">
                            <lines>
                                <line hits="0" number="5" branch="false"/>
                            </lines>
                        </method>
                        <method name="test_ci::uncovered_sum" signature="" complexity="0" line-rate="0" branch-rate="0">
                            <lines>
                                <line hits="0" number="9" branch="false"/>
                            </lines>
                        </method>
                        <method name="test_ci::covered_bad_sum" signature="" complexity="0" line-rate="0" branch-rate="0">
                            <lines>
                                <line hits="0" number="13" branch="false"/>
                            </lines>
                        </method>
                        <method name="test_ci::run" signature="" complexity="0" line-rate="0" branch-rate="0">
                            <lines>
                                <line hits="0" number="1" branch="false"/>
                            </lines>
                        </method>
                        <method name="test_ci::two" signature="" complexity="0" line-rate="1" branch-rate="1">
                            <lines>
                                <line hits="1" number="5" branch="false"/>
                            </lines>
                        </method>
                        <method name="test_ci::tests::test_failure" signature="" complexity="0" line-rate="0" branch-rate="0">
                            <lines>
                                <line hits="0" number="30" branch="false"/>
                            </lines>
                        </method>
                        <method name="test_ci::tests::test_bad_sum" signature="" complexity="0" line-rate="1" branch-rate="1">
                            <lines>
                                <line hits="1" number="35" branch="false"/>
                            </lines>
                        </method>
                        <method name="test_ci::tests::test_success" signature="" complexity="0" line-rate="1" branch-rate="1">
                            <lines>
                                <line hits="1" number="25" branch="false"/>
                            </lines>
                        </method>
                    </methods>
                    <lines>
                        <line branch="false" hits="0" number="1"/>
                        <line branch="false" hits="0" number="2"/>
                        <line branch="false" hits="0" number="3"/>
                        <line branch="false" hits="1" number="5"/>
                        <line branch="false" hits="1" number="6"/>
                        <line branch="false" hits="1" number="7"/>
                        <line branch="false" hits="0" number="9"/>
                        <line branch="false" hits="0" number="10"/>
                        <line branch="false" hits="0" number="11"/>
                        <line branch="false" hits="1" number="13"/>
                        <line branch="false" hits="1" number="14"/>
                        <line branch="false" hits="1" number="15"/>
                        <line branch="false" hits="0" number="16"/>
                        <line branch="false" hits="0" number="17"/>
                        <line branch="false" hits="1" number="18"/>
                        <line branch="false" hits="1" number="24"/>
                        <line branch="false" hits="1" number="25"/>
                        <line branch="false" hits="1" number="26"/>
                        <line branch="false" hits="1" number="27"/>
                        <line branch="false" hits="0" number="30"/>
                        <line branch="false" hits="0" number="31"/>
                        <line branch="false" hits="0" number="32"/>
                        <line branch="false" hits="1" number="34"/>
                        <line branch="false" hits="1" number="35"/>
                        <line branch="false" hits="1" number="36"/>
                        <line branch="false" hits="1" number="37"/>
                    </lines>
                </class>
                <class branch-rate="0" complexity="0" filename="/test-ci/src/main.rs" line-rate="0" name=".test-ci.src.main.rs">
                    <methods>
                        <method name="test_ci::main" signature="" complexity="0" line-rate="0" branch-rate="0">
                            <lines>
                                <line hits="0" number="3" branch="false"/>
                            </lines>
                        </method>
                        <method name="test_ci::main" signature="" complexity="0" line-rate="0" branch-rate="0">
                            <lines>
                                <line hits="0" number="3" branch="false"/>
                            </lines>
                        </method>
                        <method name="test_ci::main" signature="" complexity="0" line-rate="0" branch-rate="0">
                            <lines>
                                <line hits="0" number="1" branch="false"/>
                            </lines>
                        </method>
                    </methods>
                    <lines>
                        <line branch="false" hits="0" number="1"/>
                        <line branch="false" hits="0" number="2"/>
                        <line branch="false" hits="0" number="3"/>
                        <line branch="false" hits="0" number="4"/>
                        <line branch="false" hits="0" number="5"/>
                    </lines>
                </class>
            </classes>
        </package>
    </packages>
</coverage>

```
</details>

which then can't be properly rendered by [GitLab test coverage visualisation](https://docs.gitlab.com/ee/ci/testing/test_coverage_visualization.html).

Proposed PR fixed generation of `<source></source>` which affects generation of `filename` attributes:
<details>
 <summary>`cobertura.xml` as produced by modified `llvm-cov report --cobertura`</summary>

```xml
<?xml version="1.0" ?>
<!DOCTYPE coverage SYSTEM "https://cobertura.sourceforge.net/xml/coverage-04.dtd">
<coverage branch-rate="0" branches-covered="0" branches-valid="0" complexity="0" line-rate="0.47058823529411764" lines-covered="8" lines-valid="17" timestamp="1692891839" version="2.0.3">
    <sources>
        <source>/test-ci</source>
    </sources>
    <packages>
        <package line-rate="0.47058823529411764" branch-rate="0" name="src" complexity="0">
            <classes>
                <class branch-rate="0" complexity="0" filename="src/lib.rs" line-rate="0.5714285714285714" name="src.lib.rs">
                    <methods>
                        <method name="test_ci::tests::test_failure::{closure#0}" signature="" complexity="0" line-rate="1" branch-rate="1">
                            <lines>
                                <line hits="1" number="16" branch="false"/>
                            </lines>
                        </method>
                        <method name="test_ci::tests::test_success::{closure#0}" signature="" complexity="0" line-rate="1" branch-rate="1">
                            <lines>
                                <line hits="1" number="11" branch="false"/>
                            </lines>
                        </method>
                        <method name="test_ci::run" signature="" complexity="0" line-rate="0" branch-rate="0">
                            <lines>
                                <line hits="0" number="1" branch="false"/>
                            </lines>
                        </method>
                        <method name="test_ci::two" signature="" complexity="0" line-rate="0" branch-rate="0">
                            <lines>
                                <line hits="0" number="5" branch="false"/>
                            </lines>
                        </method>
                        <method name="test_ci::run" signature="" complexity="0" line-rate="0" branch-rate="0">
                            <lines>
                                <line hits="0" number="1" branch="false"/>
                            </lines>
                        </method>
                        <method name="test_ci::two" signature="" complexity="0" line-rate="0" branch-rate="0">
                            <lines>
                                <line hits="0" number="5" branch="false"/>
                            </lines>
                        </method>
                        <method name="test_ci::tests::test_failure" signature="" complexity="0" line-rate="1" branch-rate="1">
                            <lines>
                                <line hits="1" number="17" branch="false"/>
                            </lines>
                        </method>
                        <method name="test_ci::tests::test_success" signature="" complexity="0" line-rate="1" branch-rate="1">
                            <lines>
                                <line hits="1" number="12" branch="false"/>
                            </lines>
                        </method>
                    </methods>
                    <lines>
                        <line branch="false" hits="0" number="1"/>
                        <line branch="false" hits="0" number="2"/>
                        <line branch="false" hits="0" number="3"/>
                        <line branch="false" hits="0" number="5"/>
                        <line branch="false" hits="0" number="6"/>
                        <line branch="false" hits="0" number="7"/>
                        <line branch="false" hits="1" number="11"/>
                        <line branch="false" hits="1" number="12"/>
                        <line branch="false" hits="1" number="13"/>
                        <line branch="false" hits="1" number="14"/>
                        <line branch="false" hits="1" number="16"/>
                        <line branch="false" hits="1" number="17"/>
                        <line branch="false" hits="1" number="18"/>
                        <line branch="false" hits="1" number="19"/>
                    </lines>
                </class>
                <class branch-rate="0" complexity="0" filename="src/main.rs" line-rate="0" name="src.main.rs">
                    <methods>
                        <method name="test_ci::main" signature="" complexity="0" line-rate="0" branch-rate="0">
                            <lines>
                                <line hits="0" number="3" branch="false"/>
                            </lines>
                        </method>
                        <method name="test_ci::main" signature="" complexity="0" line-rate="0" branch-rate="0">
                            <lines>
                                <line hits="0" number="3" branch="false"/>
                            </lines>
                        </method>
                    </methods>
                    <lines>
                        <line branch="false" hits="0" number="3"/>
                        <line branch="false" hits="0" number="4"/>
                        <line branch="false" hits="0" number="5"/>
                    </lines>
                </class>
            </classes>
        </package>
    </packages>
</coverage>
```
<details>

The corrected report is consumed by GitLab successfully and produce nice visualisation:
![GitLab report example](https://github.com/taiki-e/cargo-llvm-cov/assets/385639/dab7c462-778f-4bb7-ab03-3d620b22532b)
