### PR TITLE
docs: Use #[coverage(off)] instead of #[no_coverage]

### DIFF
--- a/README.md
+++ b/README.md
@@ -454,14 +454,14 @@ cargo llvm-cov --open --ignore-filename-regex build
 
 ### Exclude function from coverage
 
-To exclude the specific function from coverage, use the [`#[no_coverage]` attribute][rust-lang/rust#84605].
+To exclude the specific function from coverage, use the [`#[coverage(off)]` attribute][rust-lang/rust#84605].
 
-Since `#[no_coverage]` is unstable, it is recommended to use it together with `cfg(coverage)` or `cfg(coverage_nightly)` set by cargo-llvm-cov.
+Since `#[coverage(off)]` is unstable, it is recommended to use it together with `cfg(coverage)` or `cfg(coverage_nightly)` set by cargo-llvm-cov.
 
 ```rust
-#![cfg_attr(coverage_nightly, feature(no_coverage))]
+#![cfg_attr(coverage_nightly, feature(coverage_attribute))]
 
-#[cfg_attr(coverage_nightly, no_coverage)]
+#[cfg_attr(coverage_nightly, coverage(off))]
 fn exclude_from_coverage() {
     // ...
 }
@@ -472,7 +472,11 @@ cfgs are set under the following conditions:
 - `cfg(coverage)` is always set when using cargo-llvm-cov (unless `--no-cfg-coverage` flag passed)
 - `cfg(coverage_nightly)` is set when using cargo-llvm-cov with nightly toolchain (unless `--no-cfg-coverage-nightly` flag passed)
 
-If you want to ignore all `#[test]`-related code, consider using [coverage-helper] crate.
+If you want to ignore all `#[test]`-related code, consider using [coverage-helper] crate version 0.2+.
+
+cargo-llvm-cov excludes code contained in the directory named `tests` from the report by default, so you can also use it instead of coverage-helper crate.
+
+**Note:** `#[coverage(off)]` was previously named `#[no_coverage]`. When using `#[no_coverage]` in the old nightly, replace `feature(coverage_attribute)` with `feature(no_coverage)`, `coverage(off)` with `no_coverage`, and `coverage-helper` 0.2+ with `coverage-helper` 0.1.
 
 ### Continuous Integration
 

--- a/tests/fixtures/coverage-reports/coverage_helper/coverage_helper.hide-instantiations.txt
+++ b/tests/fixtures/coverage-reports/coverage_helper/coverage_helper.hide-instantiations.txt
@@ -1,4 +1,4 @@
-    1|       |#![cfg_attr(coverage_nightly, feature(no_coverage))]
+    1|       |#![cfg_attr(coverage_nightly, feature(coverage_attribute))]
     2|       |
     3|       |use coverage_helper::test;
     4|       |

--- a/tests/fixtures/coverage-reports/coverage_helper/coverage_helper.txt
+++ b/tests/fixtures/coverage-reports/coverage_helper/coverage_helper.txt
@@ -1,4 +1,4 @@
-    1|       |#![cfg_attr(coverage_nightly, feature(no_coverage))]
+    1|       |#![cfg_attr(coverage_nightly, feature(coverage_attribute))]
     2|       |
     3|       |use coverage_helper::test;
     4|       |

--- a/tests/fixtures/coverage-reports/no_coverage/no_cfg_coverage.hide-instantiations.txt
+++ b/tests/fixtures/coverage-reports/no_coverage/no_cfg_coverage.hide-instantiations.txt
@@ -1,4 +1,4 @@
-    1|       |#![cfg_attr(coverage, feature(no_coverage))]
+    1|       |#![cfg_attr(coverage, feature(coverage_attribute))]
     2|       |
     3|      1|fn func(x: i32) {
     4|      1|    match x {
@@ -10,7 +10,7 @@
    10|       |    }
    11|      1|}
    12|       |
-   13|       |#[cfg_attr(coverage, no_coverage)]
+   13|       |#[cfg_attr(coverage, coverage(off))]
    14|      1|#[test]
    15|      1|fn fn_level() {
    16|      1|    func(0);
@@ -20,17 +20,17 @@
    20|      1|    }
    21|      1|}
    22|       |
-   23|       |// #[no_coverage] has no effect on expressions.
+   23|       |// #[coverage(off)] has no effect on expressions.
    24|      1|#[test]
    25|      1|fn expr_level() {
    26|      1|    if false {
-   27|      0|        #[cfg_attr(coverage, no_coverage)]
+   27|      0|        #[cfg_attr(coverage, coverage(off))]
    28|      0|        func(2);
    29|      1|    }
    30|      1|}
    31|       |
-   32|       |// #[no_coverage] has no effect on modules.
-   33|       |#[cfg_attr(coverage, no_coverage)]
+   32|       |// #[coverage(off)] has no effect on modules.
+   33|       |#[cfg_attr(coverage, coverage(off))]
    34|       |mod mod_level {
    35|       |    use super::func;
    36|       |

--- a/tests/fixtures/coverage-reports/no_coverage/no_cfg_coverage.txt
+++ b/tests/fixtures/coverage-reports/no_coverage/no_cfg_coverage.txt
@@ -1,4 +1,4 @@
-    1|       |#![cfg_attr(coverage, feature(no_coverage))]
+    1|       |#![cfg_attr(coverage, feature(coverage_attribute))]
     2|       |
     3|      1|fn func(x: i32) {
     4|      1|    match x {
@@ -10,7 +10,7 @@
    10|       |    }
    11|      1|}
    12|       |
-   13|       |#[cfg_attr(coverage, no_coverage)]
+   13|       |#[cfg_attr(coverage, coverage(off))]
    14|      1|#[test]
    15|      1|fn fn_level() {
    16|      1|    func(0);
@@ -20,17 +20,17 @@
    20|      1|    }
    21|      1|}
    22|       |
-   23|       |// #[no_coverage] has no effect on expressions.
+   23|       |// #[coverage(off)] has no effect on expressions.
    24|      1|#[test]
    25|      1|fn expr_level() {
    26|      1|    if false {
-   27|      0|        #[cfg_attr(coverage, no_coverage)]
+   27|      0|        #[cfg_attr(coverage, coverage(off))]
    28|      0|        func(2);
    29|      1|    }
    30|      1|}
    31|       |
-   32|       |// #[no_coverage] has no effect on modules.
-   33|       |#[cfg_attr(coverage, no_coverage)]
+   32|       |// #[coverage(off)] has no effect on modules.
+   33|       |#[cfg_attr(coverage, coverage(off))]
    34|       |mod mod_level {
    35|       |    use super::func;
    36|       |

--- a/tests/fixtures/coverage-reports/no_coverage/no_coverage.hide-instantiations.txt
+++ b/tests/fixtures/coverage-reports/no_coverage/no_coverage.hide-instantiations.txt
@@ -1,4 +1,4 @@
-    1|       |#![cfg_attr(coverage, feature(no_coverage))]
+    1|       |#![cfg_attr(coverage, feature(coverage_attribute))]
     2|       |
     3|      1|fn func(x: i32) {
     4|      1|    match x {
@@ -10,7 +10,7 @@
    10|       |    }
    11|      1|}
    12|       |
-   13|       |#[cfg_attr(coverage, no_coverage)]
+   13|       |#[cfg_attr(coverage, coverage(off))]
    14|      1|#[test]
    15|       |fn fn_level() {
    16|       |    func(0);
@@ -20,17 +20,17 @@
    20|       |    }
    21|       |}
    22|       |
-   23|       |// #[no_coverage] has no effect on expressions.
+   23|       |// #[coverage(off)] has no effect on expressions.
    24|      1|#[test]
    25|      1|fn expr_level() {
    26|      1|    if false {
-   27|      0|        #[cfg_attr(coverage, no_coverage)]
+   27|      0|        #[cfg_attr(coverage, coverage(off))]
    28|      0|        func(2);
    29|      1|    }
    30|      1|}
    31|       |
-   32|       |// #[no_coverage] has no effect on modules.
-   33|       |#[cfg_attr(coverage, no_coverage)]
+   32|       |// #[coverage(off)] has no effect on modules.
+   33|       |#[cfg_attr(coverage, coverage(off))]
    34|       |mod mod_level {
    35|       |    use super::func;
    36|       |

--- a/tests/fixtures/coverage-reports/no_coverage/no_coverage.txt
+++ b/tests/fixtures/coverage-reports/no_coverage/no_coverage.txt
@@ -1,4 +1,4 @@
-    1|       |#![cfg_attr(coverage, feature(no_coverage))]
+    1|       |#![cfg_attr(coverage, feature(coverage_attribute))]
     2|       |
     3|      1|fn func(x: i32) {
     4|      1|    match x {
@@ -10,7 +10,7 @@
    10|       |    }
    11|      1|}
    12|       |
-   13|       |#[cfg_attr(coverage, no_coverage)]
+   13|       |#[cfg_attr(coverage, coverage(off))]
    14|      1|#[test]
    15|       |fn fn_level() {
    16|       |    func(0);
@@ -20,17 +20,17 @@
    20|       |    }
    21|       |}
    22|       |
-   23|       |// #[no_coverage] has no effect on expressions.
+   23|       |// #[coverage(off)] has no effect on expressions.
    24|      1|#[test]
    25|      1|fn expr_level() {
    26|      1|    if false {
-   27|      0|        #[cfg_attr(coverage, no_coverage)]
+   27|      0|        #[cfg_attr(coverage, coverage(off))]
    28|      0|        func(2);
    29|      1|    }
    30|      1|}
    31|       |
-   32|       |// #[no_coverage] has no effect on modules.
-   33|       |#[cfg_attr(coverage, no_coverage)]
+   32|       |// #[coverage(off)] has no effect on modules.
+   33|       |#[cfg_attr(coverage, coverage(off))]
    34|       |mod mod_level {
    35|       |    use super::func;
    36|       |

--- a/tests/fixtures/crates/coverage_helper/Cargo.toml
+++ b/tests/fixtures/crates/coverage_helper/Cargo.toml
@@ -6,4 +6,4 @@ edition = "2021"
 [workspace]
 
 [dependencies]
-coverage-helper = "0.1"
+coverage-helper = "0.2"

--- a/tests/fixtures/crates/coverage_helper/src/lib.rs
+++ b/tests/fixtures/crates/coverage_helper/src/lib.rs
@@ -1,4 +1,4 @@
-#![cfg_attr(coverage_nightly, feature(no_coverage))]
+#![cfg_attr(coverage_nightly, feature(coverage_attribute))]
 
 use coverage_helper::test;
 

--- a/tests/fixtures/crates/no_coverage/src/lib.rs
+++ b/tests/fixtures/crates/no_coverage/src/lib.rs
@@ -1,4 +1,4 @@
-#![cfg_attr(coverage, feature(no_coverage))]
+#![cfg_attr(coverage, feature(coverage_attribute))]
 
 fn func(x: i32) {
     match x {
@@ -10,7 +10,7 @@ fn func(x: i32) {
     }
 }
 
-#[cfg_attr(coverage, no_coverage)]
+#[cfg_attr(coverage, coverage(off))]
 #[test]
 fn fn_level() {
     func(0);
@@ -20,17 +20,17 @@ fn fn_level() {
     }
 }
 
-// #[no_coverage] has no effect on expressions.
+// #[coverage(off)] has no effect on expressions.
 #[test]
 fn expr_level() {
     if false {
-        #[cfg_attr(coverage, no_coverage)]
+        #[cfg_attr(coverage, coverage(off))]
         func(2);
     }
 }
 
-// #[no_coverage] has no effect on modules.
-#[cfg_attr(coverage, no_coverage)]
+// #[coverage(off)] has no effect on modules.
+#[cfg_attr(coverage, coverage(off))]
 mod mod_level {
     use super::func;
 

--- a/tests/test.rs
+++ b/tests/test.rs
@@ -116,7 +116,7 @@ fn cargo_config() {
     run("cargo_config_toml", "cargo_config_toml", &[], &[]);
 }
 
-// feature(no_coverage) requires nightly
+// feature(coverage_attribute) requires nightly
 #[rustversion::attr(not(nightly), ignore)]
 #[test]
 fn no_coverage() {
@@ -143,7 +143,7 @@ fn no_coverage() {
     }
 }
 
-// feature(no_coverage) requires nightly
+// feature(coverage_attribute) requires nightly
 #[rustversion::attr(not(nightly), ignore)]
 #[test]
 fn coverage_helper() {


### PR DESCRIPTION
Closes #312 

See https://github.com/rust-lang/rust/pull/114656 and https://github.com/taiki-e/cargo-llvm-cov/issues/312 for the context.

> ### Exclude function from coverage
>
> To exclude the specific function from coverage, use the `#[coverage(off)]` attribute.
>
> Since `#[coverage(off)]` is unstable, it is recommended to use it together with `cfg(coverage)` or `cfg(coverage_nightly)` set by cargo-llvm-cov.
>
> ```rust
> #![cfg_attr(coverage_nightly, feature(coverage_attribute))]
> 
> #[cfg_attr(coverage_nightly, coverage(off))]
> fn exclude_from_coverage() {
>     // ...
> }
> ```
> 
> ...
>
> If you want to ignore all `#[test]`-related code, consider using [coverage-helper] crate version 0.2+.
> 
> cargo-llvm-cov excludes code contained in the directory named `tests` from the report by default, so you can also use it instead of coverage-helper crate.
>
> **Note:** `#[coverage(off)]` was previously named `#[no_coverage]`. When using `#[no_coverage]` in the old nightly, replace `feature(coverage_attribute)` with `feature(no_coverage)`, `coverage(off)` with `no_coverage`, and `coverage-helper` 0.2+ with `coverage-helper` 0.1.