### PR TITLE
Use default name instead of unwrap when getting workspace root file name

### DIFF
--- a/src/cargo.rs
+++ b/src/cargo.rs
@@ -88,7 +88,8 @@ impl Workspace {
         let output_dir = metadata.target_directory.join("llvm-cov");
         let doctests_dir = target_dir.join("doctestbins");
 
-        let name = metadata.workspace_root.file_name().expect("Don't use / as workspace root").to_owned();
+        let name =
+            metadata.workspace_root.file_name().expect("Don't use / as workspace root").to_owned();
         let profdata_file = target_dir.join(format!("{name}.profdata"));
 
         Ok(Self {

--- a/src/cargo.rs
+++ b/src/cargo.rs
@@ -88,7 +88,7 @@ impl Workspace {
         let output_dir = metadata.target_directory.join("llvm-cov");
         let doctests_dir = target_dir.join("doctestbins");
 
-        let name = metadata.workspace_root.file_name().unwrap().to_owned();
+        let name = metadata.workspace_root.file_name().expect("Don't use / as workspace root").to_owned();
         let profdata_file = target_dir.join(format!("{name}.profdata"));
 
         Ok(Self {

--- a/src/cargo.rs
+++ b/src/cargo.rs
@@ -88,8 +88,7 @@ impl Workspace {
         let output_dir = metadata.target_directory.join("llvm-cov");
         let doctests_dir = target_dir.join("doctestbins");
 
-        let name =
-            metadata.workspace_root.file_name().expect("Don't use / as workspace root").to_owned();
+        let name = metadata.workspace_root.file_name().unwrap_or("default").to_owned();
         let profdata_file = target_dir.join(format!("{name}.profdata"));
 
         Ok(Self {


### PR DESCRIPTION
When trying to execute my tests in a docker container, I encountered the following error which was quite unclear. This PR aims to add more context to this error.

```thread 'main' panicked at src/cargo.rs:91:56:
called `Option::unwrap()` on a `None` value
stack backtrace:
   0:     0x7f0ce1e7510f - <unknown>
   1:     0x7f0ce1d6eb7c - <unknown>
   2:     0x7f0ce1e3e4cd - <unknown>
   3:     0x7f0ce1e7696e - <unknown>
   4:     0x7f0ce1e76553 - <unknown>
   5:     0x7f0ce1e77519 - <unknown>
   6:     0x7f0ce1e77018 - <unknown>
   7:     0x7f0ce1e76fa6 - <unknown>
   8:     0x7f0ce1e76f91 - <unknown>
   9:     0x7f0ce1c486d4 - <unknown>
  10:     0x7f0ce1c488a2 - <unknown>
  11:     0x7f0ce1c91911 - <unknown>
  12:     0x7f0ce1ca1f89 - <unknown>
  13:     0x7f0ce1ca9c9a - <unknown>
  14:     0x7f0ce1ca9598 - <unknown>
  15:     0x7f0ce1c63033 - <unknown>
  16:     0x7f0ce1cc7a29 - <unknown>
```