### PR TITLE
feat: add skip-functions parameter

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,8 @@ Note: In this file, do not use the hard wrap in the middle of a sentence for com
 
 ## [Unreleased]
 
+- Add `skip-functions` parameter to coverage generation.
+
 ## [0.6.4] - 2024-01-25
 
 - Make `home` dependency Windows-only dependency.

--- a/README.md
+++ b/README.md
@@ -115,6 +115,11 @@ OPTIONS:
 
             This flag can only be used together with --json, --lcov, or --cobertura.
 
+        --skip-functions
+            Skip exporting per-function coverage data.
+
+            This flag can only be used together with --json, --lcov, or --cobertura.
+
         --output-path <PATH>
             Specify a file to write coverage data into.
 

--- a/docs/cargo-llvm-cov-report.txt
+++ b/docs/cargo-llvm-cov-report.txt
@@ -65,6 +65,11 @@ OPTIONS:
 
             This flag can only be used together with --json, --lcov, or --cobertura.
 
+        --skip-functions
+            Skip exporting per-function coverage data.
+
+            This flag can only be used together with --json, --lcov, or --cobertura.
+
         --output-path <PATH>
             Specify a file to write coverage data into.
 

--- a/docs/cargo-llvm-cov-run.txt
+++ b/docs/cargo-llvm-cov-run.txt
@@ -69,6 +69,11 @@ OPTIONS:
 
             This flag can only be used together with --json, --lcov, or --cobertura.
 
+        --skip-functions
+            Skip exporting per-function coverage data.
+
+            This flag can only be used together with --json, --lcov, or --cobertura.
+
         --output-path <PATH>
             Specify a file to write coverage data into.
 

--- a/docs/cargo-llvm-cov-test.txt
+++ b/docs/cargo-llvm-cov-test.txt
@@ -74,6 +74,11 @@ OPTIONS:
 
             This flag can only be used together with --json, --lcov, or --cobertura.
 
+        --skip-functions
+            Skip exporting per-function coverage data.
+
+            This flag can only be used together with --json, --lcov, or --cobertura.
+
         --output-path <PATH>
             Specify a file to write coverage data into.
 

--- a/docs/cargo-llvm-cov.txt
+++ b/docs/cargo-llvm-cov.txt
@@ -69,6 +69,11 @@ OPTIONS:
 
             This flag can only be used together with --json, --lcov, or --cobertura.
 
+        --skip-functions
+            Skip exporting per-function coverage data.
+
+            This flag can only be used together with --json, --lcov, or --cobertura.
+
         --output-path <PATH>
             Specify a file to write coverage data into.
 

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -234,6 +234,7 @@ impl Args {
         let mut fail_uncovered_functions = None;
         let mut show_missing_lines = false;
         let mut include_build_script = false;
+        let mut skip_functions = false;
 
         // build options
         let mut release = false;
@@ -389,6 +390,7 @@ impl Args {
                 Long("html") => parse_flag!(html),
                 Long("open") => parse_flag!(open),
                 Long("summary-only") => parse_flag!(summary_only),
+                Long("skip-functions") => parse_flag!(skip_functions),
                 Long("output-path") => parse_opt!(output_path),
                 Long("output-dir") => parse_opt!(output_dir),
                 Long("failure-mode") => parse_opt!(failure_mode),
@@ -784,6 +786,12 @@ impl Args {
                 conflicts(flag, "--open")?;
             }
         }
+        if skip_functions {
+            let flag = "--skip-functions";
+            if html {
+                conflicts(flag, "--html")?;
+            }
+        }
         if output_dir.is_some() {
             let flag = "--output-dir";
             if json {
@@ -867,6 +875,7 @@ impl Args {
                 fail_uncovered_functions,
                 show_missing_lines,
                 include_build_script,
+                skip_functions,
             },
             show_env: ShowEnvOptions { export_prefix },
             doctests,
@@ -1100,6 +1109,8 @@ pub(crate) struct LlvmCovOptions {
     pub(crate) show_missing_lines: bool,
     /// Include build script in coverage report.
     pub(crate) include_build_script: bool,
+    /// Skip functions in coverage report.
+    pub(crate) skip_functions: bool,
 }
 
 impl LlvmCovOptions {

--- a/src/main.rs
+++ b/src/main.rs
@@ -976,6 +976,9 @@ impl Format {
                 if cx.args.cov.summary_only {
                     cmd.arg("-summary-only");
                 }
+                if cx.args.cov.skip_functions {
+                    cmd.arg("-skip-functions");
+                }
             }
             Self::None => {}
         }


### PR DESCRIPTION
Using --skip-functions parameter no code coverage for functions will be generated. It works together with lcov, json and cobertura.

Difference in generation using --skip-functions.

**With: 34kb**
SF:cargo.rs
FNF:16
FNH:13
DA:39,45
DA:40,45
DA:41,45
DA:42,45
DA:43,45
...

**Without: 244kb**
SF:cargo.rs
FN:73,_RNCNvMNtCs3JuV3kxdPEi_14cargo_llvm_cov5cargoNtB4_9Workspace3new0B6_
FN:163,_RNCNvMs_NtCs3JuV3kxdPEi_14cargo_llvm_cov5cargoNtB6_12RustcVersion5parse0B8_
FN:153,_RNCNvNtCs3JuV3kxdPEi_14cargo_llvm_cov5cargo13rustc_version0B5_
FN:131,_RNCNvMNtCs3JuV3kxdPEi_14cargo_llvm_cov5cargoNtB4_9Workspace11rustc_print0B6_
FN:196,_RNvNtCs3JuV3kxdPEi_14cargo_llvm_cov5cargo16test_or_run_args
...

https://llvm.org/docs/CommandGuide/llvm-cov.html