### PR TITLE
Prepend `target` if no explicit target directory is set

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -784,9 +784,7 @@ fn object_files(cx: &Context) -> Result<Vec<OsString>> {
     }
     if !auto_detect_profile {
         // https://doc.rust-lang.org/nightly/cargo/guide/build-cache.html
-        if let Some(target) = &cx.args.target {
-            target_dir.push(target);
-        }
+        target_dir.push(cx.args.target.as_deref().unwrap_or("target"));
         // https://doc.rust-lang.org/nightly/cargo/reference/profiles.html#custom-profiles
         let profile = match cx.args.profile.as_deref() {
             None if cx.args.release => "release",


### PR DESCRIPTION
This commit prepend `target` to the profile target directory path, if no explicit target is set. This is necessary to allow using a custom `--profile` flag via `cargo llvm-cov report`. Without this change I get the following error message:

```
$ cargo llvm-cov report --profile test-jenkins
warning: not found object files (searched directories: /builds/test-project/target/llvm-cov-target/test-jenkins); this may occur if show-env subcommand is used incorrectly (see docs or other warnings), or unsupported commands are used
No filenames specified!
```

This can be worked around at the calling site by using `target/test-jenkins` as profile name. That means calling `cargo llvm-cov --profile target/test-jenkins` seems to work fine.