### PR TITLE
provide for cargo afl, but it is not complete.

### DIFF
--- a/.github/.cspell/project-dictionary.txt
+++ b/.github/.cspell/project-dictionary.txt
@@ -29,3 +29,4 @@ gotcpu
 showmap
 tmin
 whatsup
+LOOPCOUNT

--- a/.github/.cspell/project-dictionary.txt
+++ b/.github/.cspell/project-dictionary.txt
@@ -23,3 +23,9 @@ winapi
 xargo
 Xdemangler
 xtask
+addseeds
+cmin
+gotcpu
+showmap
+tmin
+whatsup

--- a/docs/cargo-llvm-cov-afl.txt
+++ b/docs/cargo-llvm-cov-afl.txt
@@ -1,0 +1,26 @@
+cargo-llvm-cov-afl
+
+Use cargo llvm-cov afl to fuzz test your Rust projects with American Fuzzy Lop (AFL), a powerful fuzz testing tool that automatically finds bugs by feeding unexpected inputs to your programs.
+
+SUBCOMMANDS:
+  addseeds       Invoke afl-addseeds
+  analyze        Invoke afl-analyze
+  cmin           Invoke afl-cmin
+  config         Build or rebuild AFL++
+  fuzz           Invoke afl-fuzz
+  gotcpu         Invoke afl-gotcpu
+  plot           Invoke afl-plot
+  showmap        Invoke afl-showmap
+  system-config  Invoke afl-system-config (beware, called with sudo!)
+  tmin           Invoke afl-tmin
+  whatsup        Invoke afl-whatsup
+  help           Print this message or the help of the given subcommand(s)
+
+Arguments:
+  [ARGS]...  
+
+Options:
+  -h, --help     Print help
+  -V, --version  Print version
+
+In addition to the subcommands above, Cargo subcommands are also supported (see `cargo help` for a list of all Cargo subcommands).

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -947,6 +947,9 @@ pub(crate) enum Subcommand {
     /// Build and archive tests with cargo nextest
     NextestArchive,
 
+    /// Run afl with cargo nextest
+    Afl,
+
     // internal (unstable)
     Demangle,
 }
@@ -960,6 +963,7 @@ static CARGO_LLVM_COV_SHOW_ENV_USAGE: &str = include_str!("../docs/cargo-llvm-co
 static CARGO_LLVM_COV_NEXTEST_USAGE: &str = include_str!("../docs/cargo-llvm-cov-nextest.txt");
 static CARGO_LLVM_COV_NEXTEST_ARCHIVE_USAGE: &str =
     include_str!("../docs/cargo-llvm-cov-nextest-archive.txt");
+static CARGO_LLVM_COV_AFL_USAGE: &str = include_str!("../docs/cargo-llvm-cov-afl.txt");
 
 impl Subcommand {
     fn can_passthrough(subcommand: Self) -> bool {
@@ -976,6 +980,7 @@ impl Subcommand {
             Self::ShowEnv => CARGO_LLVM_COV_SHOW_ENV_USAGE,
             Self::Nextest { .. } => CARGO_LLVM_COV_NEXTEST_USAGE,
             Self::NextestArchive => CARGO_LLVM_COV_NEXTEST_ARCHIVE_USAGE,
+            Self::Afl => CARGO_LLVM_COV_AFL_USAGE,
             Self::Demangle => "", // internal API
         }
     }
@@ -990,6 +995,7 @@ impl Subcommand {
             Self::ShowEnv => "show-env",
             Self::Nextest { .. } => "nextest",
             Self::NextestArchive => "nextest-archive",
+            Self::Afl => "afl",
             Self::Demangle => "demangle",
         }
     }
@@ -1011,6 +1017,7 @@ impl FromStr for Subcommand {
             "show-env" => Ok(Self::ShowEnv),
             "nextest" => Ok(Self::Nextest { archive_file: false }),
             "nextest-archive" => Ok(Self::NextestArchive),
+            "afl" => Ok(Self::Afl),
             "demangle" => Ok(Self::Demangle),
             _ => bail!("unrecognized subcommand {s}"),
         }

--- a/src/main.rs
+++ b/src/main.rs
@@ -537,9 +537,9 @@ fn run_afl(cx: &Context) -> Result<()> {
         let seeds = vec!["example input 1", "sample data 2", "test case 3"];
 
         for (index, seed) in seeds.into_iter().enumerate() {
-            let file_path = format!("{}seed_{}.txt", input_dir, index);
+            let file_path = format!("{input_dir}seed_{index}.txt");
             let path = Path::new(&file_path);
-            let mut file = fs::File::create(&path)?;
+            let mut file = fs::File::create(path)?;
             file.write_all(seed.as_bytes())?;
         }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -512,11 +512,11 @@ fn run_afl(cx: &Context) -> Result<()> {
 
     set_env(cx, &mut cargo, IsNextest(false))?;
 
-    let indir = "inputs/";
-    let outdir = "outputs/";
+    let input_dir = "inputs/";
+    let output_dir = "outputs/";
 
-    fs::create_dir_all(indir)?;
-    fs::create_dir_all(outdir)?;
+    fs::create_dir_all(input_dir)?;
+    fs::create_dir_all(output_dir)?;
 
     if !cx.args.ignore_run_fail {
         {
@@ -537,21 +537,21 @@ fn run_afl(cx: &Context) -> Result<()> {
         let seeds = vec!["example input 1", "sample data 2", "test case 3"];
 
         for (index, seed) in seeds.into_iter().enumerate() {
-            let file_path = format!("{}seed_{}.txt", indir, index);
+            let file_path = format!("{}seed_{}.txt", input_dir, index);
             let path = Path::new(&file_path);
             let mut file = fs::File::create(&path)?;
             file.write_all(seed.as_bytes())?;
         }
 
-        // set AFL_FUZZER_LOOPCOUNT to 1000 to avoid AFL loop infinitely!
+        // set afl's loop count to 1000 to avoid AFL loop infinitely!
         // AFL maybe exits a process several minutes later and produce a cov file.
         cargo.set("AFL_FUZZER_LOOPCOUNT", "20")?;
         cargo.arg("afl").arg("fuzz");
         cargo.arg("-V").arg("10");
         // set in and out
-        cargo.arg("-i").arg(indir);
-        cargo.arg("-o").arg(outdir);
-        // set the execuable
+        cargo.arg("-i").arg(input_dir);
+        cargo.arg("-o").arg(output_dir);
+        // set the executable
         let bin_file = cx.ws.target_dir.join("debug").join(cx.ws.name.clone()).to_string();
         cargo.arg(bin_file.as_str());
 


### PR DESCRIPTION
Hi! I've added initial support for cargo afl, but it's not perfect. I'm not quite sure what the norms are for contributing code, and to what extent it can be merged.

Running `cargo llvm-cov afl` will run afl for 10 seconds (I'll modify it later to let the user set their own parameters for time, etc.) and get a report.