### PR TITLE
Add unstable --dep-coverage option

### DIFF
--- a/README.md
+++ b/README.md
@@ -115,11 +115,6 @@ OPTIONS:
 
             This flag can only be used together with --json, --lcov, or --cobertura.
 
-        --skip-functions
-            Skip exporting per-function coverage data.
-
-            This flag can only be used together with --json, --lcov, or --cobertura.
-
         --output-path <PATH>
             Specify a file to write coverage data into.
 
@@ -177,6 +172,14 @@ OPTIONS:
 
         --include-build-script
             Include build script in coverage report
+
+        --dep-coverage <NAME>
+            Show coverage of th specified dependency instead of the crates in the current workspace. (unstable)
+
+        --skip-functions
+            Skip exporting per-function coverage data.
+
+            This flag can only be used together with --json, --lcov, or --cobertura.
 
         --doctests
             Including doc tests (unstable)

--- a/docs/cargo-llvm-cov-report.txt
+++ b/docs/cargo-llvm-cov-report.txt
@@ -65,11 +65,6 @@ OPTIONS:
 
             This flag can only be used together with --json, --lcov, or --cobertura.
 
-        --skip-functions
-            Skip exporting per-function coverage data.
-
-            This flag can only be used together with --json, --lcov, or --cobertura.
-
         --output-path <PATH>
             Specify a file to write coverage data into.
 
@@ -114,6 +109,14 @@ OPTIONS:
 
         --include-build-script
             Include build script in coverage report
+
+        --dep-coverage <NAME>
+            Show coverage of th specified dependency instead of the crates in the current workspace. (unstable)
+
+        --skip-functions
+            Skip exporting per-function coverage data.
+
+            This flag can only be used together with --json, --lcov, or --cobertura.
 
         --doctests
             Including doc tests (unstable)

--- a/docs/cargo-llvm-cov-run.txt
+++ b/docs/cargo-llvm-cov-run.txt
@@ -69,11 +69,6 @@ OPTIONS:
 
             This flag can only be used together with --json, --lcov, or --cobertura.
 
-        --skip-functions
-            Skip exporting per-function coverage data.
-
-            This flag can only be used together with --json, --lcov, or --cobertura.
-
         --output-path <PATH>
             Specify a file to write coverage data into.
 
@@ -131,6 +126,14 @@ OPTIONS:
 
         --include-build-script
             Include build script in coverage report
+
+        --dep-coverage <NAME>
+            Show coverage of th specified dependency instead of the crates in the current workspace. (unstable)
+
+        --skip-functions
+            Skip exporting per-function coverage data.
+
+            This flag can only be used together with --json, --lcov, or --cobertura.
 
         --ignore-run-fail
             Run all tests regardless of failure and generate report

--- a/docs/cargo-llvm-cov-test.txt
+++ b/docs/cargo-llvm-cov-test.txt
@@ -74,11 +74,6 @@ OPTIONS:
 
             This flag can only be used together with --json, --lcov, or --cobertura.
 
-        --skip-functions
-            Skip exporting per-function coverage data.
-
-            This flag can only be used together with --json, --lcov, or --cobertura.
-
         --output-path <PATH>
             Specify a file to write coverage data into.
 
@@ -136,6 +131,14 @@ OPTIONS:
 
         --include-build-script
             Include build script in coverage report
+
+        --dep-coverage <NAME>
+            Show coverage of th specified dependency instead of the crates in the current workspace. (unstable)
+
+        --skip-functions
+            Skip exporting per-function coverage data.
+
+            This flag can only be used together with --json, --lcov, or --cobertura.
 
         --doctests
             Including doc tests (unstable)

--- a/docs/cargo-llvm-cov.txt
+++ b/docs/cargo-llvm-cov.txt
@@ -69,11 +69,6 @@ OPTIONS:
 
             This flag can only be used together with --json, --lcov, or --cobertura.
 
-        --skip-functions
-            Skip exporting per-function coverage data.
-
-            This flag can only be used together with --json, --lcov, or --cobertura.
-
         --output-path <PATH>
             Specify a file to write coverage data into.
 
@@ -131,6 +126,14 @@ OPTIONS:
 
         --include-build-script
             Include build script in coverage report
+
+        --dep-coverage <NAME>
+            Show coverage of th specified dependency instead of the crates in the current workspace. (unstable)
+
+        --skip-functions
+            Skip exporting per-function coverage data.
+
+            This flag can only be used together with --json, --lcov, or --cobertura.
 
         --doctests
             Including doc tests (unstable)

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -236,6 +236,7 @@ impl Args {
         let mut fail_uncovered_functions = None;
         let mut show_missing_lines = false;
         let mut include_build_script = false;
+        let mut dep_coverage = None;
         let mut skip_functions = false;
 
         // build options
@@ -420,6 +421,7 @@ impl Args {
                 Long("fail-uncovered-functions") => parse_opt!(fail_uncovered_functions),
                 Long("show-missing-lines") => parse_flag!(show_missing_lines),
                 Long("include-build-script") => parse_flag!(include_build_script),
+                Long("dep-coverage") => parse_opt!(dep_coverage),
 
                 // show-env options
                 Long("export-prefix") => parse_flag!(export_prefix),
@@ -882,6 +884,7 @@ impl Args {
                 fail_uncovered_functions,
                 show_missing_lines,
                 include_build_script,
+                dep_coverage,
                 skip_functions,
             },
             show_env: ShowEnvOptions { export_prefix },
@@ -1117,6 +1120,8 @@ pub(crate) struct LlvmCovOptions {
     pub(crate) show_missing_lines: bool,
     /// Include build script in coverage report.
     pub(crate) include_build_script: bool,
+    /// Show coverage of th specified dependency instead of the crates in the current workspace. (unstable)
+    pub(crate) dep_coverage: Option<String>,
     /// Skip functions in coverage report.
     pub(crate) skip_functions: bool,
 }

--- a/src/context.rs
+++ b/src/context.rs
@@ -62,6 +62,9 @@ impl Context {
             if args.cov.disable_default_ignore_filename_regex {
                 warn!("--disable-default-ignore-filename-regex option is unstable");
             }
+            if args.cov.dep_coverage.is_some() {
+                warn!("--dep-coverage option is unstable");
+            }
             if args.doc {
                 warn!("--doc option is unstable");
             } else if args.doctests {

--- a/src/json.rs
+++ b/src/json.rs
@@ -16,7 +16,7 @@ use serde_derive::{Deserialize, Serialize};
 #[cfg_attr(test, serde(deny_unknown_fields))]
 pub struct LlvmCovJsonExport {
     /// List of one or more export objects
-    data: Vec<Export>,
+    pub data: Vec<Export>,
     // llvm.coverage.json.export
     #[serde(rename = "type")]
     type_: String,
@@ -319,9 +319,9 @@ impl LlvmCovJsonExport {
 /// Json representation of one `CoverageMapping`
 #[derive(Debug, Serialize, Deserialize)]
 #[cfg_attr(test, serde(deny_unknown_fields))]
-struct Export {
+pub struct Export {
     /// List of objects describing coverage for files
-    files: Vec<File>,
+    pub files: Vec<File>,
     /// List of objects describing coverage for functions
     ///
     /// This is None if report is summary-only.
@@ -333,7 +333,7 @@ struct Export {
 /// Coverage for a single file
 #[derive(Debug, Serialize, Deserialize)]
 #[cfg_attr(test, serde(deny_unknown_fields))]
-struct File {
+pub struct File {
     /// List of Branches in the file
     ///
     /// This is None if report is summary-only.
@@ -345,7 +345,7 @@ struct File {
     /// This is None if report is summary-only.
     #[serde(skip_serializing_if = "Option::is_none")]
     expansions: Option<Vec<serde_json::Value>>,
-    filename: String,
+    pub filename: String,
     /// List of Segments contained in the file
     ///
     /// This is None if report is summary-only.


### PR DESCRIPTION
By default, cargo-llvm-cov only shows coverage of crates in the workspace.

This can be disabled by `--disable-default-ignore-filename-regex` flag. However, in this case, coverage of crates and all dependencies in the workspace will be shown.
<img width="500" alt="disable-default-ignore-filename-regex" src="https://github.com/taiki-e/cargo-llvm-cov/assets/43724913/9931b383-86a2-409e-acd8-2c455d8c7c94">


If you specify a dependency with the `--dep-coverage` option that this PR adds, only the coverage of that dependency will be shown. The following is using `--dep-coverage memchr`:
<img width="250" alt="dep-coverage" src="https://github.com/taiki-e/cargo-llvm-cov/assets/43724913/0c4a02e0-e4a5-497d-8763-9c0476969d26">

The option is currently marked as unstable due to limitations such as not yet being able to show coverage other than dependencies from crates.io.

cc @xizheyin