### PR TITLE
Add --nextest-archive-file option to report subcommand

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -85,19 +85,23 @@ jobs:
           cd ../real1
           cargo llvm-cov nextest-archive --archive-file a.tar.zst
           cargo llvm-cov nextest --archive-file a.tar.zst --text --fail-under-lines 70
+          cargo llvm-cov report --nextest-archive-file a.tar.zst --fail-under-lines 70
           rm a.tar.zst
           cargo clean
           cargo llvm-cov nextest-archive --archive-file a.tar.zst --release
           cargo llvm-cov nextest --archive-file a.tar.zst --text --fail-under-lines 70
+          cargo llvm-cov report --nextest-archive-file a.tar.zst --fail-under-lines 70
           rm a.tar.zst
           cargo clean
           cargo llvm-cov nextest-archive --archive-file a.tar.zst --cargo-profile custom
           cargo llvm-cov nextest --archive-file a.tar.zst --text --fail-under-lines 70
+          cargo llvm-cov report --nextest-archive-file a.tar.zst --fail-under-lines 70
           rm a.tar.zst
           cargo clean
           host=$(rustc -Vv | grep host | sed 's/host: //')
           cargo llvm-cov nextest-archive --archive-file a.tar.zst --target "${host}"
           cargo llvm-cov nextest --archive-file a.tar.zst --text --fail-under-lines 70
+          cargo llvm-cov report --nextest-archive-file a.tar.zst --fail-under-lines 70
         working-directory: tests/fixtures/crates/bin_crate
       - run: |
           set -eEuxo pipefail

--- a/docs/cargo-llvm-cov-report.txt
+++ b/docs/cargo-llvm-cov-report.txt
@@ -77,6 +77,9 @@ OPTIONS:
             This flag can only be used together with --text, --html, or --open. See also
             --output-path.
 
+        --nextest-archive-file <PATH>
+            Path to nextest archive
+
         --failure-mode <any|all>
             Fail if `any` or `all` profiles cannot be merged (default to `any`)
 

--- a/src/cargo.rs
+++ b/src/cargo.rs
@@ -223,8 +223,8 @@ pub(crate) fn test_or_run_args(cx: &Context, cmd: &mut ProcessBuilder) {
         if cx.args.release {
             cmd.arg("--release");
         }
-        if let Some(profile) = &cx.args.profile {
-            if cx.args.subcommand.is_nextest_based() {
+        if let Some(profile) = &cx.args.cargo_profile {
+            if cx.args.subcommand.call_cargo_nextest() {
                 cmd.arg("--cargo-profile");
             } else {
                 cmd.arg("--profile");
@@ -253,7 +253,7 @@ pub(crate) fn clean_args(cx: &Context, cmd: &mut ProcessBuilder) {
     if cx.args.release {
         cmd.arg("--release");
     }
-    if let Some(profile) = &cx.args.profile {
+    if let Some(profile) = &cx.args.cargo_profile {
         cmd.arg("--profile");
         cmd.arg(profile);
     }

--- a/src/context.rs
+++ b/src/context.rs
@@ -77,7 +77,7 @@ impl Context {
                  not be displayed because cargo does not pass RUSTFLAGS to them"
             );
         }
-        if !matches!(args.subcommand, Subcommand::Report | Subcommand::Clean)
+        if !matches!(args.subcommand, Subcommand::Report { .. } | Subcommand::Clean)
             && (!args.cov.no_cfg_coverage
                 || ws.rustc_version.nightly && !args.cov.no_cfg_coverage_nightly)
         {
@@ -101,14 +101,14 @@ impl Context {
         if args.cov.output_dir.is_none() && args.cov.html {
             args.cov.output_dir = Some(ws.output_dir.clone());
         }
-        if !matches!(args.subcommand, Subcommand::Report | Subcommand::Clean)
+        if !matches!(args.subcommand, Subcommand::Report { .. } | Subcommand::Clean)
             && env::var_os("CARGO_LLVM_COV_SHOW_ENV").is_some()
         {
             warn!(
                 "cargo-llvm-cov subcommands other than report and clean may not work correctly \
                  in context where environment variables are set by show-env; consider using \
                  normal {} commands",
-                if args.subcommand.is_nextest_based() { "cargo-nextest" } else { "cargo" }
+                if args.subcommand.call_cargo_nextest() { "cargo-nextest" } else { "cargo" }
             );
         }
 


### PR DESCRIPTION
Support calling `cargo llvm-cov report` for the result of `cargo llvm-cov nextest --archive-file`.

https://github.com/taiki-e/cargo-llvm-cov/blob/f9c74390eed23105d0067af75ca4dd1068e52211/.github/workflows/ci.yml#L86-L88

cc @weiznich

Closes #350