### PR TITLE
Add unstable --branch flag

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -76,7 +76,8 @@ jobs:
       - run: cargo test --workspace --all-features
       # TODO: move this test to tests/test.rs
       - run: cargo install --path . --debug
-      - run: |
+      - name: Test cargo llvm-cov nextest
+        run: |
           set -eEuxo pipefail
           cargo llvm-cov nextest --text --fail-under-lines 50
           cargo llvm-cov nextest --text --fail-under-lines 50 --profile default --cargo-profile dev
@@ -103,20 +104,35 @@ jobs:
           cargo llvm-cov nextest --archive-file a.tar.zst --text --fail-under-lines 70
           cargo llvm-cov report --nextest-archive-file a.tar.zst --fail-under-lines 70
         working-directory: tests/fixtures/crates/bin_crate
-      - run: |
+      - name: Test nightly-specific options, old Cargo compatibility, trybuild compatibility
+        run: |
           set -eEuxo pipefail
+
+          # Test nightly-specific options
           git clone https://github.com/taiki-e/easytime.git
-          cd easytime
+          pushd easytime >/dev/null
           git checkout 7ecb6e6
           cargo llvm-cov test --doctests --text --fail-under-lines 30
+          popd >/dev/null
+          pushd tests/fixtures/crates/cargo_config >/dev/null
+          # TODO: --fail-under-branches?
+          cargo llvm-cov test --branch --text --fail-under-lines 80
+          popd >/dev/null
+          pushd easytime >/dev/null
+          cargo llvm-cov test --branch --doctests --text --fail-under-lines 30
+          popd >/dev/null
+
           # Test minimum runnable Cargo version.
           rustup toolchain add 1.60 --no-self-update
+          pushd easytime >/dev/null
           cargo +1.60 llvm-cov test --text --fail-under-lines 30
-          cd ..
+          popd >/dev/null
+
           # Test trybuild compatibility.
           git clone --depth 1 https://github.com/taiki-e/easy-ext.git
-          cd easy-ext
+          pushd easy-ext >/dev/null
           cargo llvm-cov --text --test compiletest --fail-under-lines 70
+          popd >/dev/null
         if: startsWith(matrix.rust, 'nightly')
       - run: cargo hack build --workspace --no-private --feature-powerset --no-dev-deps
       - run: cargo minimal-versions build --workspace --no-private --detach-path-deps=skip-exact --all-features

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,8 @@ Note: In this file, do not use the hard wrap in the middle of a sentence for com
 
 ## [Unreleased]
 
+- Add unstable `--branch` flag to include branch coverage. ([#356](https://github.com/taiki-e/cargo-llvm-cov/pull/356))
+
 ## [0.6.7] - 2024-03-10
 
 - Add `--nextest-archive-file` option to `cargo llvm-cov report` to support calling it for the result of `cargo llvm-cov nextest --archive-file`. ([#355](https://github.com/taiki-e/cargo-llvm-cov/pull/355))

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ Cargo subcommand to easily use LLVM source-based code coverage.
 
 This is a wrapper around rustc [`-C instrument-coverage`][instrument-coverage] and provides:
 
-- Generate very precise coverage data. (line coverage and region coverage)
+- Generate very precise coverage data. (line, region, and branch coverage. branch coverage is currently optional and requires nightly, see [#8] for more)
 - Support `cargo test`, `cargo run`, and [`cargo nextest`][nextest] with command-line interface compatible with cargo.
 - Support for proc-macro, including coverage of UI tests.
 - Support for doc tests. (this is currently optional and requires nightly, see [#2] for more)
@@ -180,6 +180,9 @@ OPTIONS:
             Skip exporting per-function coverage data.
 
             This flag can only be used together with --json, --lcov, or --cobertura.
+
+        --branch
+            Include branch coverage. (unstable)
 
         --doctests
             Including doc tests (unstable)
@@ -685,7 +688,7 @@ pacman -S cargo-llvm-cov
 
 ## Known limitations
 
-- Branch coverage is not supported yet. See [#8] and [rust-lang/rust#79649] for more.
+- Support for branch coverage is unstable. See [#8] and [rust-lang/rust#79649] for more.
 - Support for doc tests is unstable and has known issues. See [#2] and [rust-lang/rust#79417] for more.
 
 See also [the code-coverage-related issues reported in rust-lang/rust](https://github.com/rust-lang/rust/labels/A-code-coverage).

--- a/docs/cargo-llvm-cov-run.txt
+++ b/docs/cargo-llvm-cov-run.txt
@@ -135,6 +135,9 @@ OPTIONS:
 
             This flag can only be used together with --json, --lcov, or --cobertura.
 
+        --branch
+            Include branch coverage. (unstable)
+
         --ignore-run-fail
             Run all tests regardless of failure and generate report
 

--- a/docs/cargo-llvm-cov-test.txt
+++ b/docs/cargo-llvm-cov-test.txt
@@ -140,6 +140,9 @@ OPTIONS:
 
             This flag can only be used together with --json, --lcov, or --cobertura.
 
+        --branch
+            Include branch coverage. (unstable)
+
         --doctests
             Including doc tests (unstable)
 

--- a/docs/cargo-llvm-cov.txt
+++ b/docs/cargo-llvm-cov.txt
@@ -135,6 +135,9 @@ OPTIONS:
 
             This flag can only be used together with --json, --lcov, or --cobertura.
 
+        --branch
+            Include branch coverage. (unstable)
+
         --doctests
             Including doc tests (unstable)
 

--- a/src/cargo.rs
+++ b/src/cargo.rs
@@ -40,6 +40,7 @@ impl Workspace {
         options: &ManifestOptions,
         target: Option<&str>,
         doctests: bool,
+        branch: bool,
         show_env: bool,
     ) -> Result<Self> {
         // Metadata and config
@@ -57,6 +58,9 @@ impl Workspace {
 
         if doctests && !rustc_version.nightly {
             bail!("--doctests flag requires nightly toolchain; consider using `cargo +nightly llvm-cov`")
+        }
+        if branch && !rustc_version.nightly {
+            bail!("--branch flag requires nightly toolchain; consider using `cargo +nightly llvm-cov`")
         }
         let stable_coverage =
             rustc.clone().args(["-C", "help"]).read()?.contains("instrument-coverage");

--- a/src/clean.rs
+++ b/src/clean.rs
@@ -21,7 +21,7 @@ use crate::{
 };
 
 pub(crate) fn run(args: &mut Args) -> Result<()> {
-    let ws = Workspace::new(&args.manifest, None, false, false)?;
+    let ws = Workspace::new(&args.manifest, None, false, false, false)?;
     cli::merge_config_to_args(&ws, &mut None, &mut args.verbose, &mut args.color);
     term::set_coloring(&mut args.color);
 

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -355,6 +355,8 @@ pub(crate) struct LlvmCovOptions {
     pub(crate) dep_coverage: Option<String>,
     /// Skip functions in coverage report.
     pub(crate) skip_functions: bool,
+    /// Include branch coverage. (unstable)
+    pub(crate) branch: bool,
 }
 
 impl LlvmCovOptions {
@@ -508,6 +510,7 @@ impl Args {
         let mut include_build_script = false;
         let mut dep_coverage = None;
         let mut skip_functions = false;
+        let mut branch = false;
 
         // build options
         let mut release = false;
@@ -666,6 +669,7 @@ impl Args {
                 Long("open") => parse_flag!(open),
                 Long("summary-only") => parse_flag!(summary_only),
                 Long("skip-functions") => parse_flag!(skip_functions),
+                Long("branch") => parse_flag!(branch),
                 Long("output-path") => parse_opt!(output_path),
                 Long("output-dir") => parse_opt!(output_dir),
                 Long("failure-mode") => parse_opt!(failure_mode),
@@ -1185,6 +1189,7 @@ impl Args {
                 include_build_script,
                 dep_coverage,
                 skip_functions,
+                branch,
             },
             show_env: ShowEnvOptions { export_prefix },
             doctests,

--- a/src/context.rs
+++ b/src/context.rs
@@ -46,7 +46,13 @@ pub(crate) struct Context {
 impl Context {
     pub(crate) fn new(mut args: Args) -> Result<Self> {
         let show_env = args.subcommand == Subcommand::ShowEnv;
-        let ws = Workspace::new(&args.manifest, args.target.as_deref(), args.doctests, show_env)?;
+        let ws = Workspace::new(
+            &args.manifest,
+            args.target.as_deref(),
+            args.doctests,
+            args.cov.branch,
+            show_env,
+        )?;
         cli::merge_config_to_args(&ws, &mut args.target, &mut args.verbose, &mut args.color);
         term::set_coloring(&mut args.color);
         term::verbose::set(args.verbose != 0);
@@ -64,6 +70,9 @@ impl Context {
             }
             if args.cov.dep_coverage.is_some() {
                 warn!("--dep-coverage option is unstable");
+            }
+            if args.cov.branch {
+                warn!("--branch option is unstable");
             }
             if args.doc {
                 warn!("--doc option is unstable");

--- a/src/main.rs
+++ b/src/main.rs
@@ -195,13 +195,19 @@ fn set_env(cx: &Context, env: &mut dyn EnvTarget, IsNextest(is_nextest): IsNexte
                 flags.push("codegen-units=1");
             }
         }
+        if cx.args.cov.branch {
+            // Tracking issue: https://github.com/rust-lang/rust/issues/79649
+            flags.push("-Z");
+            flags.push("coverage-options=branch");
+        }
         // Workaround for https://github.com/rust-lang/rust/issues/91092.
         // Unnecessary since https://github.com/rust-lang/rust/pull/111469.
-        if if cx.ws.rustc_version.nightly {
+        let needs_atomic_counter_workaround = if cx.ws.rustc_version.nightly {
             cx.ws.rustc_version.minor <= 71
         } else {
             cx.ws.rustc_version.minor < 71
-        } {
+        };
+        if needs_atomic_counter_workaround {
             flags.push("-C");
             flags.push("llvm-args=--instrprof-atomic-counter-update-all");
         }


### PR DESCRIPTION
cc #8 

With this change, when the `--branch` flag is passed cargo-llvm-cov now adds `-Z coverage-options=branch` to rustflags/rustdocflags. (-show-branches is already passed since https://github.com/taiki-e/cargo-llvm-cov/pull/308) See https://github.com/rust-lang/rust/issues/79649#issuecomment-1999562694 for more.

This requires nightly-2024-03-16+.

<img width="351" alt="branch" src="https://github.com/taiki-e/cargo-llvm-cov/assets/43724913/38c5a7f9-e26c-414a-b9fc-9a77eb8c3918">
