### PR TITLE
Skip merging profraw data if profraw files don't exist and a profdata file already exists

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -650,11 +650,15 @@ fn merge_profraw(cx: &Context) -> Result<()> {
     .filter_map(Result::ok)
     .collect::<Vec<_>>();
     if profraw_files.is_empty() {
-        warn!(
-            "not found *.profraw files in {}; this may occur if target directory is accidentally \
-             cleared, or running report subcommand without running any tests or binaries",
-            cx.ws.target_dir
-        );
+        if cx.ws.profdata_file.exists() {
+            return Ok(());
+        } else {
+            warn!(
+                "not found *.profraw files in {}; this may occur if target directory is accidentally \
+                 cleared, or running report subcommand without running any tests or binaries",
+                cx.ws.target_dir
+            );
+        }
     }
     let mut input_files = String::new();
     for path in profraw_files {

--- a/src/main.rs
+++ b/src/main.rs
@@ -655,7 +655,7 @@ fn merge_profraw(cx: &Context) -> Result<()> {
         }
         warn!(
             "not found *.profraw files in {}; this may occur if target directory is accidentally \
-                 cleared, or running report subcommand without running any tests or binaries",
+             cleared, or running report subcommand without running any tests or binaries",
             cx.ws.target_dir
         );
     }

--- a/src/main.rs
+++ b/src/main.rs
@@ -652,13 +652,12 @@ fn merge_profraw(cx: &Context) -> Result<()> {
     if profraw_files.is_empty() {
         if cx.ws.profdata_file.exists() {
             return Ok(());
-        } else {
-            warn!(
-                "not found *.profraw files in {}; this may occur if target directory is accidentally \
-                 cleared, or running report subcommand without running any tests or binaries",
-                cx.ws.target_dir
-            );
         }
+        warn!(
+            "not found *.profraw files in {}; this may occur if target directory is accidentally \
+                 cleared, or running report subcommand without running any tests or binaries",
+            cx.ws.target_dir
+        );
     }
     let mut input_files = String::new();
     for path in profraw_files {


### PR DESCRIPTION
This change allows skipping merging the profraw data if a profdata file already exists. For distributed test runs (like for example nextests partitions) this allows merging the profraw files manually on each runner and only transfer the much smaller profdata file to the final job. There we can just merge the different profdata files manually and place it in the correct location. By allowing tho skip this check we can then use the existing cargo-llvm-cov infrastructure to generate reports.