### PR TITLE
Add support for MC/DC coverage

### DIFF
--- a/.github/.cspell/project-dictionary.txt
+++ b/.github/.cspell/project-dictionary.txt
@@ -8,6 +8,7 @@ fcoverage
 fprofile
 instrprof
 libhello
+mcdc
 microkernel
 MSYSTEM
 nextest

--- a/src/main.rs
+++ b/src/main.rs
@@ -1013,7 +1013,16 @@ impl Format {
                     "-show-line-counts-or-regions",
                     "-show-expansions",
                     "-show-branches=count",
-                    "-show-mcdc",
+                ]);
+                if cmd!(&cx.llvm_cov, "show", "--help")
+                    .read()
+                    .unwrap_or_default()
+                    .contains("-show-mcdc")
+                {
+                    // -show-mcdc requires LLVM 18+
+                    cmd.arg("-show-mcdc");
+                }
+                cmd.args([
                     &format!("-Xdemangler={}", cx.current_exe.display()),
                     "-Xdemangler=llvm-cov",
                     "-Xdemangler=demangle",

--- a/src/main.rs
+++ b/src/main.rs
@@ -1013,6 +1013,7 @@ impl Format {
                     "-show-line-counts-or-regions",
                     "-show-expansions",
                     "-show-branches=count",
+                    "-show-mcdc",
                     &format!("-Xdemangler={}", cx.current_exe.display()),
                     "-Xdemangler=llvm-cov",
                     "-Xdemangler=demangle",


### PR DESCRIPTION
MC/DC coverage recently landed in `rustc`:

- https://github.com/rust-lang/rust/pull/123409
- https://github.com/rust-lang/rust/pull/124217

but `cargo-llvm-cov` doesn't yet pass the `-show-mcdc` flag to `llvm-cov`, so we cannot get reports showing MC/DC coverage.

This PR adds support for `-show-mcdc` to `llvm-cov` when working with `cargo-llvm-cov`.

I checked: if `RUSTFLAGS` contains `-Zcoverage-options=branch` (i.e., MC/DC is not enabled) then the reports are the same as if you didn't pass `-show-mcdc` (i.e., you don't get "empty" MC/DC tables).