### PR TITLE
Add `--mcdc` flag, and handle MC/DC fields correctly in LLVM JSON

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -115,9 +115,11 @@ jobs:
           pushd -- tests/fixtures/crates/cargo_config >/dev/null
           # TODO: --fail-under-branches?
           cargo llvm-cov test --branch --text --fail-under-lines 80
+          cargo llvm-cov test --mcdc --text --fail-under-lines 80
           popd >/dev/null
           pushd -- easytime >/dev/null
           cargo llvm-cov test --branch --doctests --text --fail-under-lines 30
+          cargo llvm-cov test --mcdc --doctests --text --fail-under-lines 30
           popd >/dev/null
 
           # Test minimum runnable Cargo version.

--- a/README.md
+++ b/README.md
@@ -184,6 +184,9 @@ OPTIONS:
         --branch
             Enable branch coverage. (unstable)
 
+        --mcdc
+            Enable mcdc coverage. (unstable)
+
         --doctests
             Including doc tests (unstable)
 

--- a/docs/cargo-llvm-cov-run.txt
+++ b/docs/cargo-llvm-cov-run.txt
@@ -138,6 +138,9 @@ OPTIONS:
         --branch
             Enable branch coverage. (unstable)
 
+        --mcdc
+            Enable mcdc coverage. (unstable)
+
         --ignore-run-fail
             Run all tests regardless of failure and generate report
 

--- a/docs/cargo-llvm-cov-test.txt
+++ b/docs/cargo-llvm-cov-test.txt
@@ -143,6 +143,9 @@ OPTIONS:
         --branch
             Enable branch coverage. (unstable)
 
+        --mcdc
+            Enable mcdc coverage. (unstable)
+
         --doctests
             Including doc tests (unstable)
 

--- a/docs/cargo-llvm-cov.txt
+++ b/docs/cargo-llvm-cov.txt
@@ -138,6 +138,9 @@ OPTIONS:
         --branch
             Enable branch coverage. (unstable)
 
+        --mcdc
+            Enable mcdc coverage. (unstable)
+
         --doctests
             Including doc tests (unstable)
 

--- a/src/cargo.rs
+++ b/src/cargo.rs
@@ -36,11 +36,13 @@ pub(crate) struct Workspace {
 }
 
 impl Workspace {
+    #[allow(clippy::fn_params_excessive_bools)]
     pub(crate) fn new(
         options: &ManifestOptions,
         target: Option<&str>,
         doctests: bool,
         branch: bool,
+        mcdc: bool,
         show_env: bool,
     ) -> Result<Self> {
         // Metadata and config
@@ -63,6 +65,11 @@ impl Workspace {
         }
         if branch && !rustc_version.nightly {
             bail!("--branch flag requires nightly toolchain; consider using `cargo +nightly llvm-cov`")
+        }
+        if mcdc && !rustc_version.nightly {
+            bail!(
+                "--mcdc flag requires nightly toolchain; consider using `cargo +nightly llvm-cov`"
+            )
         }
         let stable_coverage =
             rustc.clone().args(["-C", "help"]).read()?.contains("instrument-coverage");

--- a/src/clean.rs
+++ b/src/clean.rs
@@ -21,7 +21,7 @@ use crate::{
 };
 
 pub(crate) fn run(args: &mut Args) -> Result<()> {
-    let ws = Workspace::new(&args.manifest, None, false, false, false)?;
+    let ws = Workspace::new(&args.manifest, None, false, false, false, false)?;
     cli::merge_config_to_args(&ws, &mut None, &mut args.verbose, &mut args.color);
     term::set_coloring(&mut args.color);
 

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -359,6 +359,8 @@ pub(crate) struct LlvmCovOptions {
     pub(crate) skip_functions: bool,
     /// Enable branch coverage. (unstable)
     pub(crate) branch: bool,
+    /// Enable mcdc coverage. (unstable)
+    pub(crate) mcdc: bool,
 }
 
 impl LlvmCovOptions {
@@ -513,6 +515,7 @@ impl Args {
         let mut dep_coverage = None;
         let mut skip_functions = false;
         let mut branch = false;
+        let mut mcdc = false;
 
         // build options
         let mut release = false;
@@ -678,6 +681,7 @@ impl Args {
                 Long("summary-only") => parse_flag!(summary_only),
                 Long("skip-functions") => parse_flag!(skip_functions),
                 Long("branch") => parse_flag!(branch),
+                Long("mcdc") => parse_flag!(mcdc),
                 Long("output-path") => parse_opt!(output_path),
                 Long("output-dir") => parse_opt!(output_dir),
                 Long("failure-mode") => parse_opt!(failure_mode),
@@ -1204,6 +1208,7 @@ impl Args {
                 dep_coverage,
                 skip_functions,
                 branch,
+                mcdc,
             },
             show_env: ShowEnvOptions { export_prefix },
             doctests,

--- a/src/context.rs
+++ b/src/context.rs
@@ -51,6 +51,7 @@ impl Context {
             args.target.as_deref(),
             args.doctests,
             args.cov.branch,
+            args.cov.mcdc,
             show_env,
         )?;
         cli::merge_config_to_args(&ws, &mut args.target, &mut args.verbose, &mut args.color);
@@ -73,6 +74,12 @@ impl Context {
             }
             if args.cov.branch {
                 warn!("--branch option is unstable");
+            }
+            if args.cov.mcdc {
+                warn!("--mcdc option is unstable");
+            }
+            if args.cov.mcdc && args.cov.branch {
+                warn!("the `--mcdc` option takes precedence over `--branch`");
             }
             if args.doc {
                 warn!("--doc option is unstable");

--- a/src/json.rs
+++ b/src/json.rs
@@ -340,6 +340,11 @@ pub struct File {
     /// This is None if report is summary-only.
     #[serde(skip_serializing_if = "Option::is_none")]
     branches: Option<Vec<serde_json::Value>>,
+    /// List of MC/DC records contained in the file
+    ///
+    /// This is None if report is summary-only.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    mcdc_records: Option<Vec<serde_json::Value>>,
     /// List of expansion records
     ///
     /// This is None if report is summary-only.
@@ -406,6 +411,8 @@ impl fmt::Debug for Segment {
 #[cfg_attr(test, serde(deny_unknown_fields))]
 struct Function {
     branches: Vec<serde_json::Value>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    mcdc_records: Option<Vec<serde_json::Value>>,
     count: u64,
     /// List of filenames that the function relates to
     filenames: Vec<String>,
@@ -500,6 +507,9 @@ impl RegionLocation {
 struct Summary {
     /// Object summarizing branch coverage
     branches: CoverageCounts,
+    /// Object summarizing mcdc coverage
+    #[serde(skip_serializing_if = "Option::is_none")]
+    mcdc: Option<CoverageCounts>,
     /// Object summarizing function coverage
     functions: CoverageCounts,
     instantiations: CoverageCounts,

--- a/src/main.rs
+++ b/src/main.rs
@@ -194,7 +194,11 @@ fn set_env(cx: &Context, env: &mut dyn EnvTarget, IsNextest(is_nextest): IsNexte
                 flags.push("codegen-units=1");
             }
         }
-        if cx.args.cov.branch {
+        if cx.args.cov.mcdc {
+            // Tracking issue: https://github.com/rust-lang/rust/issues/124144
+            flags.push("-Z");
+            flags.push("coverage-options=mcdc");
+        } else if cx.args.cov.branch {
             // Tracking issue: https://github.com/rust-lang/rust/issues/79649
             flags.push("-Z");
             flags.push("coverage-options=branch");

--- a/tests/fixtures/coverage-reports/bin_crate/bin_crate.json
+++ b/tests/fixtures/coverage-reports/bin_crate/bin_crate.json
@@ -11,6 +11,12 @@
               "notcovered": 0,
               "percent": 0.0
             },
+            "mcdc": {
+              "count": 0,
+              "covered": 0,
+              "notcovered": 0,
+              "percent": 0.0
+            },
             "functions": {
               "count": 1,
               "covered": 1,

--- a/tests/fixtures/coverage-reports/bin_crate/run.json
+++ b/tests/fixtures/coverage-reports/bin_crate/run.json
@@ -11,6 +11,12 @@
               "notcovered": 0,
               "percent": 0.0
             },
+            "mcdc": {
+              "count": 0,
+              "covered": 0,
+              "notcovered": 0,
+              "percent": 0.0
+            },
             "functions": {
               "count": 1,
               "covered": 1,

--- a/tests/fixtures/coverage-reports/cargo_config/cargo_config.json
+++ b/tests/fixtures/coverage-reports/cargo_config/cargo_config.json
@@ -11,6 +11,12 @@
               "notcovered": 0,
               "percent": 0.0
             },
+            "mcdc": {
+              "count": 0,
+              "covered": 0,
+              "notcovered": 0,
+              "percent": 0.0
+            },
             "functions": {
               "count": 2,
               "covered": 2,

--- a/tests/fixtures/coverage-reports/cargo_config_toml/cargo_config_toml.json
+++ b/tests/fixtures/coverage-reports/cargo_config_toml/cargo_config_toml.json
@@ -11,6 +11,12 @@
               "notcovered": 0,
               "percent": 0.0
             },
+            "mcdc": {
+              "count": 0,
+              "covered": 0,
+              "notcovered": 0,
+              "percent": 0.0
+            },
             "functions": {
               "count": 2,
               "covered": 2,

--- a/tests/fixtures/coverage-reports/coverage_helper/coverage_helper.json
+++ b/tests/fixtures/coverage-reports/coverage_helper/coverage_helper.json
@@ -11,6 +11,12 @@
               "notcovered": 0,
               "percent": 0.0
             },
+            "mcdc": {
+              "count": 0,
+              "covered": 0,
+              "notcovered": 0,
+              "percent": 0.0
+            },
             "functions": {
               "count": 1,
               "covered": 1,

--- a/tests/fixtures/coverage-reports/instantiations/instantiations.json
+++ b/tests/fixtures/coverage-reports/instantiations/instantiations.json
@@ -11,6 +11,12 @@
               "notcovered": 0,
               "percent": 0.0
             },
+            "mcdc": {
+              "count": 0,
+              "covered": 0,
+              "notcovered": 0,
+              "percent": 0.0
+            },
             "functions": {
               "count": 2,
               "covered": 2,

--- a/tests/fixtures/coverage-reports/merge/clean_ws.json
+++ b/tests/fixtures/coverage-reports/merge/clean_ws.json
@@ -11,6 +11,12 @@
               "notcovered": 0,
               "percent": 0.0
             },
+            "mcdc": {
+              "count": 0,
+              "covered": 0,
+              "notcovered": 0,
+              "percent": 0.0
+            },
             "functions": {
               "count": 2,
               "covered": 2,

--- a/tests/fixtures/coverage-reports/merge/merge.json
+++ b/tests/fixtures/coverage-reports/merge/merge.json
@@ -11,6 +11,12 @@
               "notcovered": 0,
               "percent": 0.0
             },
+            "mcdc": {
+              "count": 0,
+              "covered": 0,
+              "notcovered": 0,
+              "percent": 0.0
+            },
             "functions": {
               "count": 2,
               "covered": 2,

--- a/tests/fixtures/coverage-reports/no_coverage/no_cfg_coverage.json
+++ b/tests/fixtures/coverage-reports/no_coverage/no_cfg_coverage.json
@@ -11,6 +11,12 @@
               "notcovered": 0,
               "percent": 0.0
             },
+            "mcdc": {
+              "count": 0,
+              "covered": 0,
+              "notcovered": 0,
+              "percent": 0.0
+            },
             "functions": {
               "count": 4,
               "covered": 4,

--- a/tests/fixtures/coverage-reports/no_coverage/no_coverage.json
+++ b/tests/fixtures/coverage-reports/no_coverage/no_coverage.json
@@ -11,6 +11,12 @@
               "notcovered": 0,
               "percent": 0.0
             },
+            "mcdc": {
+              "count": 0,
+              "covered": 0,
+              "notcovered": 0,
+              "percent": 0.0
+            },
             "functions": {
               "count": 2,
               "covered": 2,

--- a/tests/fixtures/coverage-reports/no_test/link_dead_code.json
+++ b/tests/fixtures/coverage-reports/no_test/link_dead_code.json
@@ -11,6 +11,12 @@
               "notcovered": 0,
               "percent": 0.0
             },
+            "mcdc": {
+              "count": 0,
+              "covered": 0,
+              "notcovered": 0,
+              "percent": 0.0
+            },
             "functions": {
               "count": 1,
               "covered": 1,
@@ -38,6 +44,12 @@
           "filename": "src/module.rs",
           "summary": {
             "branches": {
+              "count": 0,
+              "covered": 0,
+              "notcovered": 0,
+              "percent": 0.0
+            },
+            "mcdc": {
               "count": 0,
               "covered": 0,
               "notcovered": 0,

--- a/tests/fixtures/coverage-reports/no_test/no_test.json
+++ b/tests/fixtures/coverage-reports/no_test/no_test.json
@@ -11,6 +11,12 @@
               "notcovered": 0,
               "percent": 0.0
             },
+            "mcdc": {
+              "count": 0,
+              "covered": 0,
+              "notcovered": 0,
+              "percent": 0.0
+            },
             "functions": {
               "count": 1,
               "covered": 1,
@@ -38,6 +44,12 @@
           "filename": "src/module.rs",
           "summary": {
             "branches": {
+              "count": 0,
+              "covered": 0,
+              "notcovered": 0,
+              "percent": 0.0
+            },
+            "mcdc": {
               "count": 0,
               "covered": 0,
               "notcovered": 0,

--- a/tests/fixtures/coverage-reports/real1/all.json
+++ b/tests/fixtures/coverage-reports/real1/all.json
@@ -11,6 +11,12 @@
               "notcovered": 0,
               "percent": 0.0
             },
+            "mcdc": {
+              "count": 0,
+              "covered": 0,
+              "notcovered": 0,
+              "percent": 0.0
+            },
             "functions": {
               "count": 1,
               "covered": 1,
@@ -43,6 +49,12 @@
               "notcovered": 0,
               "percent": 0.0
             },
+            "mcdc": {
+              "count": 0,
+              "covered": 0,
+              "notcovered": 0,
+              "percent": 0.0
+            },
             "functions": {
               "count": 1,
               "covered": 1,
@@ -70,6 +82,12 @@
           "filename": "src/lib.rs",
           "summary": {
             "branches": {
+              "count": 0,
+              "covered": 0,
+              "notcovered": 0,
+              "percent": 0.0
+            },
+            "mcdc": {
               "count": 0,
               "covered": 0,
               "notcovered": 0,

--- a/tests/fixtures/coverage-reports/real1/exclude.json
+++ b/tests/fixtures/coverage-reports/real1/exclude.json
@@ -11,6 +11,12 @@
               "notcovered": 0,
               "percent": 0.0
             },
+            "mcdc": {
+              "count": 0,
+              "covered": 0,
+              "notcovered": 0,
+              "percent": 0.0
+            },
             "functions": {
               "count": 1,
               "covered": 0,
@@ -38,6 +44,12 @@
           "filename": "member1/src/lib.rs",
           "summary": {
             "branches": {
+              "count": 0,
+              "covered": 0,
+              "notcovered": 0,
+              "percent": 0.0
+            },
+            "mcdc": {
               "count": 0,
               "covered": 0,
               "notcovered": 0,

--- a/tests/fixtures/coverage-reports/real1/manifest_path.json
+++ b/tests/fixtures/coverage-reports/real1/manifest_path.json
@@ -11,6 +11,12 @@
               "notcovered": 0,
               "percent": 0.0
             },
+            "mcdc": {
+              "count": 0,
+              "covered": 0,
+              "notcovered": 0,
+              "percent": 0.0
+            },
             "functions": {
               "count": 1,
               "covered": 0,

--- a/tests/fixtures/coverage-reports/real1/package1.json
+++ b/tests/fixtures/coverage-reports/real1/package1.json
@@ -11,6 +11,12 @@
               "notcovered": 0,
               "percent": 0.0
             },
+            "mcdc": {
+              "count": 0,
+              "covered": 0,
+              "notcovered": 0,
+              "percent": 0.0
+            },
             "functions": {
               "count": 1,
               "covered": 0,

--- a/tests/fixtures/coverage-reports/real1/workspace_root.json
+++ b/tests/fixtures/coverage-reports/real1/workspace_root.json
@@ -11,6 +11,12 @@
               "notcovered": 0,
               "percent": 0.0
             },
+            "mcdc": {
+              "count": 0,
+              "covered": 0,
+              "notcovered": 0,
+              "percent": 0.0
+            },
             "functions": {
               "count": 1,
               "covered": 1,
@@ -43,6 +49,12 @@
               "notcovered": 0,
               "percent": 0.0
             },
+            "mcdc": {
+              "count": 0,
+              "covered": 0,
+              "notcovered": 0,
+              "percent": 0.0
+            },
             "functions": {
               "count": 1,
               "covered": 1,
@@ -70,6 +82,12 @@
           "filename": "src/lib.rs",
           "summary": {
             "branches": {
+              "count": 0,
+              "covered": 0,
+              "notcovered": 0,
+              "percent": 0.0
+            },
+            "mcdc": {
               "count": 0,
               "covered": 0,
               "notcovered": 0,

--- a/tests/fixtures/coverage-reports/virtual1/exclude-from-report1.json
+++ b/tests/fixtures/coverage-reports/virtual1/exclude-from-report1.json
@@ -11,6 +11,12 @@
               "notcovered": 0,
               "percent": 0.0
             },
+            "mcdc": {
+              "count": 0,
+              "covered": 0,
+              "notcovered": 0,
+              "percent": 0.0
+            },
             "functions": {
               "count": 1,
               "covered": 1,
@@ -43,6 +49,12 @@
               "notcovered": 0,
               "percent": 0.0
             },
+            "mcdc": {
+              "count": 0,
+              "covered": 0,
+              "notcovered": 0,
+              "percent": 0.0
+            },
             "functions": {
               "count": 3,
               "covered": 3,
@@ -70,6 +82,12 @@
           "filename": "member2/src/member4/src/lib.rs",
           "summary": {
             "branches": {
+              "count": 0,
+              "covered": 0,
+              "notcovered": 0,
+              "percent": 0.0
+            },
+            "mcdc": {
               "count": 0,
               "covered": 0,
               "notcovered": 0,

--- a/tests/fixtures/coverage-reports/virtual1/exclude-from-report2.json
+++ b/tests/fixtures/coverage-reports/virtual1/exclude-from-report2.json
@@ -11,6 +11,12 @@
               "notcovered": 0,
               "percent": 0.0
             },
+            "mcdc": {
+              "count": 0,
+              "covered": 0,
+              "notcovered": 0,
+              "percent": 0.0
+            },
             "functions": {
               "count": 2,
               "covered": 2,
@@ -43,6 +49,12 @@
               "notcovered": 0,
               "percent": 0.0
             },
+            "mcdc": {
+              "count": 0,
+              "covered": 0,
+              "notcovered": 0,
+              "percent": 0.0
+            },
             "functions": {
               "count": 1,
               "covered": 1,
@@ -70,6 +82,12 @@
           "filename": "member2/src/member4/src/lib.rs",
           "summary": {
             "branches": {
+              "count": 0,
+              "covered": 0,
+              "notcovered": 0,
+              "percent": 0.0
+            },
+            "mcdc": {
               "count": 0,
               "covered": 0,
               "notcovered": 0,

--- a/tests/fixtures/coverage-reports/virtual1/exclude-from-test1.json
+++ b/tests/fixtures/coverage-reports/virtual1/exclude-from-test1.json
@@ -11,6 +11,12 @@
               "notcovered": 0,
               "percent": 0.0
             },
+            "mcdc": {
+              "count": 0,
+              "covered": 0,
+              "notcovered": 0,
+              "percent": 0.0
+            },
             "functions": {
               "count": 1,
               "covered": 0,
@@ -43,6 +49,12 @@
               "notcovered": 0,
               "percent": 0.0
             },
+            "mcdc": {
+              "count": 0,
+              "covered": 0,
+              "notcovered": 0,
+              "percent": 0.0
+            },
             "functions": {
               "count": 3,
               "covered": 2,
@@ -70,6 +82,12 @@
           "filename": "member2/src/member4/src/lib.rs",
           "summary": {
             "branches": {
+              "count": 0,
+              "covered": 0,
+              "notcovered": 0,
+              "percent": 0.0
+            },
+            "mcdc": {
               "count": 0,
               "covered": 0,
               "notcovered": 0,

--- a/tests/fixtures/coverage-reports/virtual1/exclude-from-test2.json
+++ b/tests/fixtures/coverage-reports/virtual1/exclude-from-test2.json
@@ -11,6 +11,12 @@
               "notcovered": 0,
               "percent": 0.0
             },
+            "mcdc": {
+              "count": 0,
+              "covered": 0,
+              "notcovered": 0,
+              "percent": 0.0
+            },
             "functions": {
               "count": 2,
               "covered": 2,
@@ -38,6 +44,12 @@
           "filename": "member2/member3/src/lib.rs",
           "summary": {
             "branches": {
+              "count": 0,
+              "covered": 0,
+              "notcovered": 0,
+              "percent": 0.0
+            },
+            "mcdc": {
               "count": 0,
               "covered": 0,
               "notcovered": 0,
@@ -75,6 +87,12 @@
               "notcovered": 0,
               "percent": 0.0
             },
+            "mcdc": {
+              "count": 0,
+              "covered": 0,
+              "notcovered": 0,
+              "percent": 0.0
+            },
             "functions": {
               "count": 2,
               "covered": 1,
@@ -102,6 +120,12 @@
           "filename": "member2/src/member4/src/lib.rs",
           "summary": {
             "branches": {
+              "count": 0,
+              "covered": 0,
+              "notcovered": 0,
+              "percent": 0.0
+            },
+            "mcdc": {
               "count": 0,
               "covered": 0,
               "notcovered": 0,

--- a/tests/fixtures/coverage-reports/virtual1/exclude1.json
+++ b/tests/fixtures/coverage-reports/virtual1/exclude1.json
@@ -11,6 +11,12 @@
               "notcovered": 0,
               "percent": 0.0
             },
+            "mcdc": {
+              "count": 0,
+              "covered": 0,
+              "notcovered": 0,
+              "percent": 0.0
+            },
             "functions": {
               "count": 1,
               "covered": 0,
@@ -43,6 +49,12 @@
               "notcovered": 0,
               "percent": 0.0
             },
+            "mcdc": {
+              "count": 0,
+              "covered": 0,
+              "notcovered": 0,
+              "percent": 0.0
+            },
             "functions": {
               "count": 3,
               "covered": 2,
@@ -70,6 +82,12 @@
           "filename": "member2/src/member4/src/lib.rs",
           "summary": {
             "branches": {
+              "count": 0,
+              "covered": 0,
+              "notcovered": 0,
+              "percent": 0.0
+            },
+            "mcdc": {
               "count": 0,
               "covered": 0,
               "notcovered": 0,

--- a/tests/fixtures/coverage-reports/virtual1/exclude2.json
+++ b/tests/fixtures/coverage-reports/virtual1/exclude2.json
@@ -11,6 +11,12 @@
               "notcovered": 0,
               "percent": 0.0
             },
+            "mcdc": {
+              "count": 0,
+              "covered": 0,
+              "notcovered": 0,
+              "percent": 0.0
+            },
             "functions": {
               "count": 2,
               "covered": 2,
@@ -43,6 +49,12 @@
               "notcovered": 0,
               "percent": 0.0
             },
+            "mcdc": {
+              "count": 0,
+              "covered": 0,
+              "notcovered": 0,
+              "percent": 0.0
+            },
             "functions": {
               "count": 1,
               "covered": 1,
@@ -70,6 +82,12 @@
           "filename": "member2/src/member4/src/lib.rs",
           "summary": {
             "branches": {
+              "count": 0,
+              "covered": 0,
+              "notcovered": 0,
+              "percent": 0.0
+            },
+            "mcdc": {
               "count": 0,
               "covered": 0,
               "notcovered": 0,

--- a/tests/fixtures/coverage-reports/virtual1/package1.json
+++ b/tests/fixtures/coverage-reports/virtual1/package1.json
@@ -11,6 +11,12 @@
               "notcovered": 0,
               "percent": 0.0
             },
+            "mcdc": {
+              "count": 0,
+              "covered": 0,
+              "notcovered": 0,
+              "percent": 0.0
+            },
             "functions": {
               "count": 2,
               "covered": 2,
@@ -38,6 +44,12 @@
           "filename": "member2/member3/src/lib.rs",
           "summary": {
             "branches": {
+              "count": 0,
+              "covered": 0,
+              "notcovered": 0,
+              "percent": 0.0
+            },
+            "mcdc": {
               "count": 0,
               "covered": 0,
               "notcovered": 0,
@@ -75,6 +87,12 @@
               "notcovered": 0,
               "percent": 0.0
             },
+            "mcdc": {
+              "count": 0,
+              "covered": 0,
+              "notcovered": 0,
+              "percent": 0.0
+            },
             "functions": {
               "count": 2,
               "covered": 1,
@@ -102,6 +120,12 @@
           "filename": "member2/src/member4/src/lib.rs",
           "summary": {
             "branches": {
+              "count": 0,
+              "covered": 0,
+              "notcovered": 0,
+              "percent": 0.0
+            },
+            "mcdc": {
               "count": 0,
               "covered": 0,
               "notcovered": 0,

--- a/tests/fixtures/coverage-reports/virtual1/package2.json
+++ b/tests/fixtures/coverage-reports/virtual1/package2.json
@@ -11,6 +11,12 @@
               "notcovered": 0,
               "percent": 0.0
             },
+            "mcdc": {
+              "count": 0,
+              "covered": 0,
+              "notcovered": 0,
+              "percent": 0.0
+            },
             "functions": {
               "count": 2,
               "covered": 2,
@@ -38,6 +44,12 @@
           "filename": "member2/member3/src/lib.rs",
           "summary": {
             "branches": {
+              "count": 0,
+              "covered": 0,
+              "notcovered": 0,
+              "percent": 0.0
+            },
+            "mcdc": {
               "count": 0,
               "covered": 0,
               "notcovered": 0,
@@ -75,6 +87,12 @@
               "notcovered": 0,
               "percent": 0.0
             },
+            "mcdc": {
+              "count": 0,
+              "covered": 0,
+              "notcovered": 0,
+              "percent": 0.0
+            },
             "functions": {
               "count": 3,
               "covered": 3,
@@ -102,6 +120,12 @@
           "filename": "member2/src/member4/src/lib.rs",
           "summary": {
             "branches": {
+              "count": 0,
+              "covered": 0,
+              "notcovered": 0,
+              "percent": 0.0
+            },
+            "mcdc": {
               "count": 0,
               "covered": 0,
               "notcovered": 0,

--- a/tests/fixtures/coverage-reports/virtual1/package3.json
+++ b/tests/fixtures/coverage-reports/virtual1/package3.json
@@ -11,6 +11,12 @@
               "notcovered": 0,
               "percent": 0.0
             },
+            "mcdc": {
+              "count": 0,
+              "covered": 0,
+              "notcovered": 0,
+              "percent": 0.0
+            },
             "functions": {
               "count": 3,
               "covered": 2,

--- a/tests/fixtures/coverage-reports/virtual1/package4.json
+++ b/tests/fixtures/coverage-reports/virtual1/package4.json
@@ -11,6 +11,12 @@
               "notcovered": 0,
               "percent": 0.0
             },
+            "mcdc": {
+              "count": 0,
+              "covered": 0,
+              "notcovered": 0,
+              "percent": 0.0
+            },
             "functions": {
               "count": 1,
               "covered": 0,

--- a/tests/fixtures/coverage-reports/virtual1/package5.json
+++ b/tests/fixtures/coverage-reports/virtual1/package5.json
@@ -11,6 +11,12 @@
               "notcovered": 0,
               "percent": 0.0
             },
+            "mcdc": {
+              "count": 0,
+              "covered": 0,
+              "notcovered": 0,
+              "percent": 0.0
+            },
             "functions": {
               "count": 1,
               "covered": 0,

--- a/tests/fixtures/coverage-reports/virtual1/package6.json
+++ b/tests/fixtures/coverage-reports/virtual1/package6.json
@@ -11,6 +11,12 @@
               "notcovered": 0,
               "percent": 0.0
             },
+            "mcdc": {
+              "count": 0,
+              "covered": 0,
+              "notcovered": 0,
+              "percent": 0.0
+            },
             "functions": {
               "count": 1,
               "covered": 0,
@@ -38,6 +44,12 @@
           "filename": "member2/src/member4/src/lib.rs",
           "summary": {
             "branches": {
+              "count": 0,
+              "covered": 0,
+              "notcovered": 0,
+              "percent": 0.0
+            },
+            "mcdc": {
               "count": 0,
               "covered": 0,
               "notcovered": 0,

--- a/tests/fixtures/coverage-reports/virtual1/workspace_root.json
+++ b/tests/fixtures/coverage-reports/virtual1/workspace_root.json
@@ -11,6 +11,12 @@
               "notcovered": 0,
               "percent": 0.0
             },
+            "mcdc": {
+              "count": 0,
+              "covered": 0,
+              "notcovered": 0,
+              "percent": 0.0
+            },
             "functions": {
               "count": 2,
               "covered": 2,
@@ -38,6 +44,12 @@
           "filename": "member2/member3/src/lib.rs",
           "summary": {
             "branches": {
+              "count": 0,
+              "covered": 0,
+              "notcovered": 0,
+              "percent": 0.0
+            },
+            "mcdc": {
               "count": 0,
               "covered": 0,
               "notcovered": 0,
@@ -75,6 +87,12 @@
               "notcovered": 0,
               "percent": 0.0
             },
+            "mcdc": {
+              "count": 0,
+              "covered": 0,
+              "notcovered": 0,
+              "percent": 0.0
+            },
             "functions": {
               "count": 3,
               "covered": 3,
@@ -102,6 +120,12 @@
           "filename": "member2/src/member4/src/lib.rs",
           "summary": {
             "branches": {
+              "count": 0,
+              "covered": 0,
+              "notcovered": 0,
+              "percent": 0.0
+            },
+            "mcdc": {
               "count": 0,
               "covered": 0,
               "notcovered": 0,


### PR DESCRIPTION
This adds a new unstable `--mcdc` flag, similar to `--branch`.

Apart from that, the LLVM JSON parser also needed changes to recognize the mcdc-related fields, as it would otherwise silently drop those.

---

Clippy now rightfully complains that `Workspace::new` takes too many boolean parameters, so there surely is some more opportunity for improvement.