### PR TITLE
Weaken errors related to rustc version to warnings

### DIFF
--- a/src/cargo.rs
+++ b/src/cargo.rs
@@ -61,20 +61,20 @@ impl Workspace {
             rustc_version.nightly || env::var_os("RUSTC_BOOTSTRAP").unwrap_or_default() == "1";
 
         if doctests && !rustc_version.nightly {
-            bail!("--doctests flag requires nightly toolchain; consider using `cargo +nightly llvm-cov`")
+            warn!("--doctests flag requires nightly toolchain; consider using `cargo +nightly llvm-cov`");
         }
         if branch && !rustc_version.nightly {
-            bail!("--branch flag requires nightly toolchain; consider using `cargo +nightly llvm-cov`")
+            warn!("--branch flag requires nightly toolchain; consider using `cargo +nightly llvm-cov`");
         }
         if mcdc && !rustc_version.nightly {
-            bail!(
+            warn!(
                 "--mcdc flag requires nightly toolchain; consider using `cargo +nightly llvm-cov`"
-            )
+            );
         }
         let stable_coverage =
             rustc.clone().args(["-C", "help"]).read()?.contains("instrument-coverage");
         if !stable_coverage && !rustc_version.nightly {
-            bail!(
+            warn!(
                 "cargo-llvm-cov requires rustc 1.60+; consider updating toolchain (`rustup update`)
                  or using nightly toolchain (`cargo +nightly llvm-cov`)"
             );


### PR DESCRIPTION
Context: https://discord.com/channels/273534239310479360/957720175619215380/1318211522287243295 by @Nemo157

That error is so that users who do not read the documentation that says the flag requires a nightly compiler or warning that says it may not work with this toolchain version, do not waste their time.

However, this does not interact well with the use case of wanting to [manipulate the compiler output to fool “only" the build script](https://github.com/taiki-e/cargo-minimal-versions/issues/29), so this check needs to be weakened to a warning.