### PR TITLE
Support pwsh format for show-env export

### DIFF
--- a/.github/.cspell/project-dictionary.txt
+++ b/.github/.cspell/project-dictionary.txt
@@ -15,8 +15,10 @@ microkernel
 MSYSTEM
 nextest
 notcovered
+PowerShell
 profdata
 profraw
+pwsh
 rmeta
 rustfilt
 rustix

--- a/.github/.cspell/project-dictionary.txt
+++ b/.github/.cspell/project-dictionary.txt
@@ -15,7 +15,6 @@ microkernel
 MSYSTEM
 nextest
 notcovered
-PowerShell
 profdata
 profraw
 pwsh

--- a/README.md
+++ b/README.md
@@ -477,13 +477,11 @@ Note: cargo-llvm-cov subcommands other than `report` and `clean` may not work co
 
 Note: To include coverage for doctests you also need to pass `--doctests` to both `cargo llvm-cov show-env` and `cargo llvm-cov report`.
 
-> The same thing can be achieved in pwsh by substituting the source command with:
+> The same thing can be achieved in PowerShell 6+ by substituting the source command with:
 > 
 > ```powershell
-> Invoke-Expression (cargo llvm-cov show-env --export-pwsh-prefix | Out-String)
+> Invoke-Expression (cargo llvm-cov show-env --with-pwsh-env-prefix | Out-String)
 > ```
-> 
-> (verified for PowerShell 7 only, results may vary on older versions)
 
 ### Exclude file from coverage
 

--- a/README.md
+++ b/README.md
@@ -477,6 +477,14 @@ Note: cargo-llvm-cov subcommands other than `report` and `clean` may not work co
 
 Note: To include coverage for doctests you also need to pass `--doctests` to both `cargo llvm-cov show-env` and `cargo llvm-cov report`.
 
+> The same thing can be achieved in pwsh by substituting the source command with:
+> 
+> ```powershell
+> Invoke-Expression (cargo llvm-cov show-env --export-pwsh-prefix | Out-String)
+> ```
+> 
+> (verified for PowerShell 7 only, results may vary on older versions)
+
 ### Exclude file from coverage
 
 To exclude specific file patterns from the report, use the `--ignore-filename-regex` option.

--- a/README.md
+++ b/README.md
@@ -478,7 +478,7 @@ Note: cargo-llvm-cov subcommands other than `report` and `clean` may not work co
 Note: To include coverage for doctests you also need to pass `--doctests` to both `cargo llvm-cov show-env` and `cargo llvm-cov report`.
 
 > The same thing can be achieved in PowerShell 6+ by substituting the source command with:
-> 
+>
 > ```powershell
 > Invoke-Expression (cargo llvm-cov show-env --with-pwsh-env-prefix | Out-String)
 > ```

--- a/docs/cargo-llvm-cov-show-env.txt
+++ b/docs/cargo-llvm-cov-show-env.txt
@@ -8,9 +8,9 @@ OPTIONS:
         --export-prefix
             Prepend "export " to each line, so that the output is suitable to be sourced by bash
 
-        --export-pwsh-prefix
+        --with-pwsh-env-prefix
             Unicode escape and double quote values + prepend "$env:", so that the output is suitable
-            to be used with Invoke-Expression in pwsh.
+            to be used with Invoke-Expression in PowerShell 6+.
 
         --doctests
             Including doc tests (unstable)

--- a/docs/cargo-llvm-cov-show-env.txt
+++ b/docs/cargo-llvm-cov-show-env.txt
@@ -8,6 +8,10 @@ OPTIONS:
         --export-prefix
             Prepend "export " to each line, so that the output is suitable to be sourced by bash
 
+        --export-pwsh-prefix
+            Unicode escape and double quote values + prepend "$env:", so that the output is suitable
+            to be used with Invoke-Expression in pwsh.
+
         --doctests
             Including doc tests (unstable)
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -160,8 +160,7 @@ struct ShowEnvWriter<W: io::Write> {
 
 impl<W: io::Write> EnvTarget for ShowEnvWriter<W> {
     fn set(&mut self, key: &str, value: &str) -> Result<()> {
-        let prefix = if self.options.export_prefix { "export " } else { "" };
-        writeln!(self.writer, "{prefix}{key}={}", shell_escape::escape(value.into()))
+        writeln!(self.writer, "{}", self.options.show_env_format.export_string(key, value))
             .context("failed to write env to stdout")
     }
     fn unset(&mut self, key: &str) -> Result<()> {

--- a/tests/test.rs
+++ b/tests/test.rs
@@ -295,16 +295,15 @@ fn show_env() {
 
     cargo_llvm_cov("show-env")
         .env("CARGO_ENCODED_RUSTFLAGS", flags)
-        .arg("--export-pwsh-prefix")
+        .arg("--with-pwsh-env-prefix")
         .assert_success()
-        // Verify the 2 prefix related elements
-        .stdout_contains("$env:")
-        .stdout_contains("\"`u{")
+        // Verify the prefix related content + the encoding of "--"
+        .stdout_contains("$env:CARGO_ENCODED_RUSTFLAGS=\"`u{2d}`u{2d}")
         // Verify binary character didn't lead to incompatible output for pwsh
         .stdout_contains("`u{1f}");
     cargo_llvm_cov("show-env")
         .arg("--export-prefix")
-        .arg("--export-pwsh-prefix")
+        .arg("--with-pwsh-env-prefix")
         .assert_failure()
         .stderr_contains("may not be used together with");
 }
@@ -320,9 +319,9 @@ fn invalid_arg() {
                 .assert_failure()
                 .stderr_contains("invalid option '--export-prefix'");
             cargo_llvm_cov(subcommand)
-                .arg("--export-pwsh-prefix")
+                .arg("--with-pwsh-env-prefix")
                 .assert_failure()
-                .stderr_contains("invalid option '--export-pwsh-prefix'");
+                .stderr_contains("invalid option '--with-pwsh-env-prefix'");
         }
         if !matches!(subcommand, "" | "test") {
             if matches!(subcommand, "nextest" | "nextest-archive") {

--- a/tests/test.rs
+++ b/tests/test.rs
@@ -6,6 +6,7 @@ mod auxiliary;
 
 use std::path::Path;
 
+use cargo_config2::Flags;
 use fs_err as fs;
 
 use self::auxiliary::{
@@ -286,6 +287,26 @@ fn open_report() {
 fn show_env() {
     cargo_llvm_cov("show-env").assert_success().stdout_not_contains("export");
     cargo_llvm_cov("show-env").arg("--export-prefix").assert_success().stdout_contains("export");
+
+    let mut flags = Flags::default();
+    flags.push("--deny warnings");
+    flags.push("--cfg=tests");
+    let flags = flags.encode().unwrap();
+
+    cargo_llvm_cov("show-env")
+        .env("CARGO_ENCODED_RUSTFLAGS", flags)
+        .arg("--export-pwsh-prefix")
+        .assert_success()
+        // Verify the 2 prefix related elements
+        .stdout_contains("$env:")
+        .stdout_contains("\"`u{")
+        // Verify binary character didn't lead to incompatible output for pwsh
+        .stdout_contains("`u{1f}");
+    cargo_llvm_cov("show-env")
+        .arg("--export-prefix")
+        .arg("--export-pwsh-prefix")
+        .assert_failure()
+        .stderr_contains("may not be used together with");
 }
 
 #[test]
@@ -298,6 +319,10 @@ fn invalid_arg() {
                 .arg("--export-prefix")
                 .assert_failure()
                 .stderr_contains("invalid option '--export-prefix'");
+            cargo_llvm_cov(subcommand)
+                .arg("--export-pwsh-prefix")
+                .assert_failure()
+                .stderr_contains("invalid option '--export-pwsh-prefix'");
         }
         if !matches!(subcommand, "" | "test") {
             if matches!(subcommand, "nextest" | "nextest-archive") {


### PR DESCRIPTION
This PR demonstrates a solution for #395, with a slightly different strategy that what was discussed. 

The issues outlined there:
1. No pre-built in option for ouputing PowerShell syntax
2. PowerShell has very different (and frankly fairly obtuse) escaping rules which is an impediment for 1. Specifically, env vars like `CARGO_ENCODED_RUSTFLAGS` take non-printable characters that unix shells will accept but pwsh won't.

Additionally, the shell escape crate used is escaping [for cmd](https://docs.rs/shell-escape/0.1.5/shell_escape/windows/index.html), not pwsh and wouldn't be compatible.

Pwsh does accept embedded unicode codes in strings though. If we encode the values this way, we don't need to worry about printable vs non-printable characters nor any of the specifics for what kinds of characters need to be escaped for what kinds of strings. This is a one-time, very fast operation. Once the emitted string is executed all the escapes are gone.

This approach wouldn't be good for a general-purpose escape function, but it's perfectly suitable for this use case.

The change enables users to execute a pwsh version of the source demo:

> Invoke-Expression (cargo llvm-cov show-env --export-pwsh-prefix | Out-String)

Primary goal was to confirm this approach worked. If this is of interest, I can make any changes to the code organization, arg name, etc. The current organization is just what came to mind as I played around with the repo.

Manual test context with binary data in env:

![Pasted image 20241229144731](https://github.com/user-attachments/assets/e455b115-22a2-496d-9109-fbe28662e47a)

Intermediate state example:

![Pasted image 20241229145125](https://github.com/user-attachments/assets/563f869b-e88e-48f6-9dae-1306bfa33464)

Final result:
![Pasted image 20241229145255](https://github.com/user-attachments/assets/631cd693-c816-477a-b895-337e6d83e973)

---

Closes #395