### PR TITLE
Remove dependency on is_executable

### DIFF
--- a/.deny.toml
+++ b/.deny.toml
@@ -24,9 +24,6 @@ build.allow-build-scripts = [
     { name = "rustix" }, # via tar
     { name = "serde_json" },
     { name = "serde" },
-    { name = "winapi-i686-pc-windows-gnu" }, # via is_executable
-    { name = "winapi-x86_64-pc-windows-gnu" }, # via is_executable
-    { name = "winapi" }, # via is_executable
     { name = "windows_aarch64_gnullvm" },
     { name = "windows_aarch64_msvc" },
     { name = "windows_i686_gnu" },
@@ -39,8 +36,6 @@ build.allow-build-scripts = [
 build.bypass = [
     { name = "autocfg", allow-globs = ["tests/wrap_ignored"] }, # via fs-err
     # Import libraries are necessary because raw-dylib (requires 1.71+ for x86, 1.65+ for others) is not available on MSRV of them.
-    { name = "winapi-i686-pc-windows-gnu", allow-globs = ["lib/*.a"] }, # via is_executable
-    { name = "winapi-x86_64-pc-windows-gnu", allow-globs = ["lib/*.a"] }, # via is_executable
     { name = "windows_aarch64_gnullvm", allow-globs = ["lib/*.a"] },
     { name = "windows_aarch64_msvc", allow-globs = ["lib/*.lib"] },
     { name = "windows_i686_gnu", allow-globs = ["lib/*.a"] },

--- a/.github/.cspell/project-dictionary.txt
+++ b/.github/.cspell/project-dictionary.txt
@@ -24,7 +24,6 @@ rustfilt
 rustix
 TESTNAME
 trybuild
-winapi
 xargo
 Xdemangler
 xtask

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -28,7 +28,6 @@ cargo-config2 = "0.1.31"
 duct = "0.13.1"
 fs-err = "3"
 glob = "0.3"
-is_executable = "1"
 lcov2cobertura = "1.0.1"
 lexopt = "0.3"
 opener = { version = "0.7", default-features = false }


### PR DESCRIPTION
Due to its behavior of always returning true on WSL, the value returned by this crate could not be trusted, and we were already using our own extension checks to handle that problem.

- https://github.com/taiki-e/cargo-llvm-cov/issues/316
- https://github.com/taiki-e/cargo-llvm-cov/issues/342