### PR TITLE
feat: Support for ignoring local vendored sources

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 target
+vendor
 # There is binary in the workspace, but intentionally not committing lockfile.
 # See https://github.com/taiki-e/cargo-llvm-cov/pull/152#issuecomment-1107055622 for more.
 Cargo.lock

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -329,6 +329,9 @@ pub(crate) struct LlvmCovOptions {
     pub(crate) ignore_filename_regex: Option<String>,
     // For debugging (unstable)
     pub(crate) disable_default_ignore_filename_regex: bool,
+    // For debugging (unstable)
+    /// Disable skipping of files from vendored sources.
+    pub(crate) disable_default_ignore_vendor: bool,
     /// Show instantiations in report
     pub(crate) show_instantiations: bool,
     /// Unset cfg(coverage), which is enabled when code is built using cargo-llvm-cov.
@@ -552,6 +555,7 @@ impl Args {
         let mut failure_mode = None;
         let mut ignore_filename_regex = None;
         let mut disable_default_ignore_filename_regex = false;
+        let mut disable_default_ignore_vendor = false;
         let mut show_instantiations = false;
         let mut no_cfg_coverage = false;
         let mut no_cfg_coverage_nightly = false;
@@ -741,6 +745,9 @@ impl Args {
                 Long("ignore-filename-regex") => parse_opt!(ignore_filename_regex),
                 Long("disable-default-ignore-filename-regex") => {
                     parse_flag!(disable_default_ignore_filename_regex);
+                }
+                Long("disable-default-ignore-vendor") => {
+                    parse_flag!(disable_default_ignore_vendor);
                 }
                 Long("show-instantiations") => parse_flag!(show_instantiations),
                 Long("hide-instantiations") => {
@@ -1258,6 +1265,7 @@ impl Args {
                 failure_mode,
                 ignore_filename_regex,
                 disable_default_ignore_filename_regex,
+                disable_default_ignore_vendor,
                 show_instantiations,
                 no_cfg_coverage,
                 no_cfg_coverage_nightly,

--- a/src/context.rs
+++ b/src/context.rs
@@ -69,6 +69,9 @@ impl Context {
             if args.cov.disable_default_ignore_filename_regex {
                 warn!("--disable-default-ignore-filename-regex option is unstable");
             }
+            if args.cov.disable_default_ignore_vendor {
+                warn!("--disable-default-ignore-vendor option is unstable");
+            }
             if args.cov.dep_coverage.is_some() {
                 warn!("--dep-coverage option is unstable");
             }

--- a/src/main.rs
+++ b/src/main.rs
@@ -1314,6 +1314,14 @@ fn ignore_filename_regex(cx: &Context, object_files: &[OsString]) -> Result<Opti
             }
         }
     }
+    if !cx.args.cov.disable_default_ignore_vendor {
+        cx.ws
+            .config
+            .source
+            .iter()
+            .filter_map(|(_, source)| source.directory.as_deref())
+            .for_each(|directory| out.push_abs_path(directory));
+    }
 
     if out.0.is_empty() { Ok(None) } else { Ok(Some(out.0)) }
 }


### PR DESCRIPTION
In order to test these changes, please follow these instructions:

```sh
rm -r .cargo || mkdir $_ 
cat <<EOF > .cargo/config.toml
[patch.crates-io]
cargo-config2 = { git = "https://github.com/Altair-Bueno/cargo-config2" }
EOF
cargo vendor >> .cargo/config.toml
cargo run llvm-cov
cargo run llvm-cov --disable-default-ignore-vendor
```

I believe the help message also needs to be manually updated, right?
