### PR TITLE
Replace / with \ in vendor dirs on Windows to match llvm cov

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -12,7 +12,7 @@ use std::{
     ffi::{OsStr, OsString},
     fmt::Write as _,
     io::{self, BufRead as _, BufWriter, Read as _, Write as _},
-    path::{Path, PathBuf},
+    path::Path,
     process::ExitCode,
     time::SystemTime,
 };
@@ -1267,8 +1267,8 @@ fn ignore_filename_regex(cx: &Context, object_files: &[OsString]) -> Result<Opti
         // reserved characters for file paths, meaning a naive string replacement can safely correct
         // the paths.
         #[cfg(windows)]
-        let vendor_dirs =
-            vendor_dirs.map(|dir| PathBuf::from(dir.to_string_lossy().replace("/", "\\")));
+        let vendor_dirs = vendor_dirs
+            .map(|dir| std::path::PathBuf::from(dir.to_string_lossy().replace("/", "\\")));
 
         vendor_dirs.for_each(|directory| out.push_abs_path(directory));
 


### PR DESCRIPTION
Fixes #441. Since `\` and `/` are reserved characters in file paths on Windows, we can fix the issue with a naive string replace.

Tested by introducing a stub file:
<img width="282" height="65" alt="image" src="https://github.com/user-attachments/assets/e463ec11-4c64-44c1-9aba-b36702f2b6f3" />

Before:
<img width="479" height="60" alt="image" src="https://github.com/user-attachments/assets/897fedb7-dc69-44a2-93c7-8367ad8f0a77" />
<br>
<img width="321" height="140" alt="image" src="https://github.com/user-attachments/assets/b5fae6e9-270a-417e-8b67-f690e9855384" />

After:
<img width="491" height="64" alt="image" src="https://github.com/user-attachments/assets/a500cb74-7234-427d-b619-635711f61f67" />
<img width="316" height="127" alt="image" src="https://github.com/user-attachments/assets/9a7bc163-bc1d-4872-8028-4ed950cf6a1e" />
