### PR TITLE
Add an explicit note that `cargo build` will include instrumentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -470,7 +470,7 @@ source <(cargo llvm-cov show-env --export-prefix)
 cargo llvm-cov clean --workspace
 # Above two commands should be called before build binaries.
 
-cargo build # Build rust binaries with intrumentation
+cargo build # Build rust binaries with instrumentation.
 # Commands using binaries in target/debug/*, including `cargo test` and other cargo subcommands.
 # ...
 

--- a/README.md
+++ b/README.md
@@ -470,7 +470,7 @@ source <(cargo llvm-cov show-env --export-prefix)
 cargo llvm-cov clean --workspace
 # Above two commands should be called before build binaries.
 
-cargo build # Build rust binaries.
+cargo build # Build rust binaries with intrumentation
 # Commands using binaries in target/debug/*, including `cargo test` and other cargo subcommands.
 # ...
 


### PR DESCRIPTION
It wasn't clear to me what will be included in the binary of `cargo build` at this point. Add a note mentioning "instrumentation" to make it a bit clearer.

See: https://github.com/taiki-e/cargo-llvm-cov/issues/373#issuecomment-3131606423