### PR TITLE
Document WASM support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,8 @@ Note: In this file, do not use the hard wrap in the middle of a sentence for com
 
 ## [Unreleased]
 
+- Update documentation to mention the way to get coverage for `wasm32-unknown-unknown` target.
+
 - Exclude files named `tests.rs`/`*_tests.rs`/`*-tests.rs` from the report by default.
 
 ## [0.6.21] - 2025-10-10

--- a/README.md
+++ b/README.md
@@ -24,6 +24,7 @@ This is a wrapper around rustc [`-C instrument-coverage`][instrument-coverage] a
   - [Get coverage of AFL fuzzers](#get-coverage-of-afl-fuzzers)
   - [Exclude file from coverage](#exclude-file-from-coverage)
   - [Exclude code from coverage](#exclude-code-from-coverage)
+  - [WASM Support](#wasm-support)
   - [Continuous Integration](#continuous-integration)
     - [GitHub Actions and Codecov](#github-actions-and-codecov)
     - [GitLab CI](#gitlab-ci)
@@ -576,6 +577,10 @@ mod tests {
 ```
 
 cargo-llvm-cov excludes code contained in the directory named `tests` and file named `tests.rs`/`*_tests.rs`/`*-tests.rs` from the report by default, so you can also use it instead of `#[coverage(off)]` attribute.
+
+### WASM Support
+
+See the [`wasm-bindgen` guide](https://wasm-bindgen.github.io/wasm-bindgen/wasm-bindgen-test/coverage.html) for the way to get coverage for `wasm32-unknown-unknown` target.
 
 ### Continuous Integration
 


### PR DESCRIPTION
Since https://github.com/wasm-bindgen/wasm-bindgen/pull/4854 (by @Spxg), the `wasm-bindgen` guide has the good documentation for this.

Closes #221
Closes #337
Closes #338
Related: https://github.com/taiki-e/cargo-llvm-cov/pull/465