### PR TITLE
Fix a bug causing `--profraw-only` to remove too many files

### DIFF
--- a/src/clean.rs
+++ b/src/clean.rs
@@ -80,6 +80,10 @@ fn clean_ws(
 ) -> Result<()> {
     clean_ws_inner(ws, pkg_ids, verbose != 0, profraw_only)?;
 
+    if profraw_only {
+        return Ok(());
+    }
+
     let package_args: Vec<_> =
         pkg_ids.iter().flat_map(|id| ["--package", &ws.metadata.packages[id].name]).collect();
     let mut args_set = vec![vec![]];


### PR DESCRIPTION
This PR does two things:
- It expands the `clean_profraw_only` test to ensure that only profraw files are removed by the clean operation, and that no files are created.
- It fixes a bug that was causing `clean --profraw-only` to remove files it shouldn't.

Nits are welcome.