### PR TITLE
Support *-windows-gnullvm targets

### DIFF
--- a/.github/.cspell/project-dictionary.txt
+++ b/.github/.cspell/project-dictionary.txt
@@ -23,6 +23,7 @@ rustfilt
 rustix
 TESTNAME
 trybuild
+winapi
 xargo
 Xdemangler
 xtask

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -111,8 +111,11 @@ jobs:
           cargo llvm-cov report --nextest-archive-file a.tar.zst --fail-under-lines 70
           cargo clean
           rm -- a.tar.zst
-          host=$(rustc -vV | grep -E '^host:' | cut -d' ' -f2)
-          cargo llvm-cov nextest-archive --archive-file a.tar.zst --target "${host}"
+          target="${{ matrix.target }}"
+          if [[ -z "${target}" ]]; then
+            target=$(rustc -vV | grep -E '^host:' | cut -d' ' -f2)
+          fi
+          cargo llvm-cov nextest-archive --archive-file a.tar.zst --target "${target}"
           cargo llvm-cov nextest --archive-file a.tar.zst --text --fail-under-lines 70
           cargo llvm-cov report --nextest-archive-file a.tar.zst --fail-under-lines 70
           cargo clean
@@ -156,19 +159,31 @@ jobs:
           popd >/dev/null
 
           # Test minimum runnable Cargo version.
-          retry rustup toolchain add 1.60 --no-self-update
-          pushd -- easytime >/dev/null
-          cargo +1.60 llvm-cov test --text --fail-under-lines 30
-          popd >/dev/null
+          case "${{ matrix.target }}" in
+            *-windows-gnullvm) ;; # target unavailable on Rust 1.60.
+            *)
+              retry rustup toolchain add 1.60 --no-self-update
+              pushd -- easytime >/dev/null
+              cargo +1.60 llvm-cov test --text --fail-under-lines 30
+              popd >/dev/null
+              ;;
+          esac
 
           # Test trybuild compatibility.
-          retry git clone --depth 1 https://github.com/taiki-e/easy-ext.git
-          pushd -- easy-ext >/dev/null
-          cargo llvm-cov --text --test compiletest --fail-under-lines 70
-          popd >/dev/null
+          case "${{ matrix.target }}" in
+            *-windows-gnullvm) ;; # proc-macro coverage is not supported yet for cross-compile.
+            *)
+              retry git clone --depth 1 https://github.com/taiki-e/easy-ext.git
+              pushd -- easy-ext >/dev/null
+              cargo llvm-cov --text --test compiletest --fail-under-lines 70
+              popd >/dev/null
+              ;;
+          esac
         if: startsWith(matrix.rust, 'nightly')
       - run: cargo hack build --workspace --no-private --feature-powerset --no-dev-deps
       - run: cargo minimal-versions build --workspace --no-private --detach-path-deps=skip-exact --all-features
+        # TODO(windows-gnullvm): winapi 0.3.5 (dep of old version of termcolor)
+        if: matrix.target != 'aarch64-pc-windows-gnullvm'
 
   test-llvm:
     strategy:

--- a/README.md
+++ b/README.md
@@ -584,7 +584,7 @@ cargo-llvm-cov excludes code contained in the directory named `tests` and file n
 
 #### Windows
 
-`{x86_64,i686}-pc-windows-msvc` are confirmed to work.
+`{x86_64,i686}-pc-windows-msvc` and `{x86_64,aarch64}-pc-windows-gnullvm` are confirmed to work.
 
 As of 2025-12-30,  `x86_64-pc-windows-gnu` ([rust-lang/rust#111098](https://github.com/rust-lang/rust/issues/111098)) and `aarch64-pc-windows-msvc` ([rust-lang/rust#150123](https://github.com/rust-lang/rust/issues/150123)) are known to not work with default setup.
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -229,10 +229,11 @@ fn set_env(cx: &Context, env: &mut dyn EnvTarget, IsNextest(is_nextest): IsNexte
         if cx.ws.rustc_version.nightly && !cx.args.cov.no_cfg_coverage_nightly {
             flags.push("--cfg=coverage_nightly");
         }
-        if cx.ws.target_for_cli.as_ref().is_some_and(|target| target.ends_with("windows-gnullvm")) {
+        if cx.ws.target_for_config.triple().ends_with("-windows-gnullvm") {
+            // https://github.com/taiki-e/cargo-llvm-cov/issues/254#issuecomment-3700090953
             flags.push("-C");
             flags.push("link-arg=-Wl,--no-gc-sections");
-        };
+        }
     }
 
     let llvm_profile_file_name =


### PR DESCRIPTION
Based on the @mati865's work at https://github.com/taiki-e/cargo-llvm-cov/issues/254#issuecomment-3700090953.

Tested with `{x86_64,aarch64}-pc-windows-gnullvm`.