### PR TITLE
Use RUSTC_WRAPPER by default to pass flags to rustc

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -90,6 +90,10 @@ jobs:
       - name: Test cargo llvm-cov nextest
         run: |
           unset RUSTFLAGS
+          target="${{ matrix.target }}"
+          if [[ -z "${target}" ]]; then
+            target=$(rustc -vV | grep -E '^host:' | cut -d' ' -f2)
+          fi
           cargo llvm-cov nextest --text --fail-under-lines 50
           cargo llvm-cov nextest --text --fail-under-lines 50 --profile default --cargo-profile dev
           cargo llvm-cov nextest --text --fail-under-lines 50 --profile ci
@@ -111,10 +115,6 @@ jobs:
           cargo llvm-cov report --nextest-archive-file a.tar.zst --fail-under-lines 70
           cargo clean
           rm -- a.tar.zst
-          target="${{ matrix.target }}"
-          if [[ -z "${target}" ]]; then
-            target=$(rustc -vV | grep -E '^host:' | cut -d' ' -f2)
-          fi
           cargo llvm-cov nextest-archive --archive-file a.tar.zst --target "${target}"
           cargo llvm-cov nextest --archive-file a.tar.zst --text --fail-under-lines 70
           cargo llvm-cov report --nextest-archive-file a.tar.zst --fail-under-lines 70
@@ -140,6 +140,15 @@ jobs:
             "$@"
           }
           unset RUSTFLAGS
+          if { sed --help 2>&1 || true; } | grep -Eq -e '-i extension'; then
+            in_place=(-i '')
+          else
+            in_place=(-i)
+          fi
+          target="${{ matrix.target }}"
+          if [[ -z "${target}" ]]; then
+            target=$(rustc -vV | grep -E '^host:' | cut -d' ' -f2)
+          fi
 
           # Test nightly-specific options
           retry git clone --depth 1 https://github.com/taiki-e/easytime.git
@@ -164,22 +173,36 @@ jobs:
             *)
               retry rustup toolchain add 1.60 --no-self-update
               pushd -- easytime >/dev/null
-              cargo +1.60 llvm-cov test --text --fail-under-lines 30
+              cargo +1.60 llvm-cov test --fail-under-lines 30
               popd >/dev/null
               ;;
           esac
 
           # Test trybuild compatibility.
           case "${{ matrix.target }}" in
-            *-windows-gnullvm) ;; # proc-macro coverage is not supported yet for cross-compile.
+            aarch64-pc-windows-gnullvm) ;; # coverage is not supported yet on host (aarch64-pc-windows-msvc).
             *)
               retry git clone --depth 1 https://github.com/taiki-e/easy-ext.git
               pushd -- easy-ext >/dev/null
-              cargo llvm-cov --text --test compiletest --fail-under-lines 70
+              cargo llvm-cov --test compiletest --fail-under-lines 70
+              cargo clean
+              cargo llvm-cov --test compiletest --fail-under-lines 70 --target "${target}"
+              cargo clean
+              sed -E "${in_place[@]}" 's/trybuild = .*/trybuild = "1"/g' Cargo.toml # easy-ext uses patched trybuild
+              cargo llvm-cov --test compiletest --fail-under-lines 70
+              cargo clean
+              cargo llvm-cov --test compiletest --fail-under-lines 70 --target "${target}"
+              cargo clean
               popd >/dev/null
-              ;;
+            ;;
           esac
         if: startsWith(matrix.rust, 'nightly')
+      - name: Test --dep-coverage
+        run: |
+          cargo llvm-cov --bins --dep-coverage=regex --fail-under-lines 2 -- regex_vec
+          cargo llvm-cov --bins --dep-coverage=regex-syntax --fail-under-lines 20 -- regex_vec
+          cargo llvm-cov --bins --dep-coverage=regex --fail-under-lines 2 -- regex_vec
+          cargo llvm-cov --bins --dep-coverage=regex,regex-syntax --fail-under-lines 20 -- regex_vec
       - run: cargo hack build --workspace --no-private --feature-powerset --no-dev-deps
       - run: cargo minimal-versions build --workspace --no-private --detach-path-deps=skip-exact --all-features
         # TODO(windows-gnullvm): winapi 0.3.5 (dep of old version of termcolor)

--- a/README.md
+++ b/README.md
@@ -155,6 +155,15 @@ OPTIONS:
         --no-clean
             Build without cleaning any old build artifacts
 
+        --no-rustc-wrapper
+            Build without setting RUSTC_WRAPPER
+
+            By default, cargo-llvm-cov sets RUSTC_WRAPPER. This is usually optimal
+            for compilation time, execution time, and disk usage.
+
+            When both this flag and --target option are used, coverage for proc-macro and
+            build script will not be displayed because cargo does not pass RUSTFLAGS to them.
+
         --fail-under-functions <MIN>
             Exit with a status of 1 if the total function coverage is less than MIN percent
 
@@ -180,7 +189,8 @@ OPTIONS:
             Include build script in coverage report
 
         --dep-coverage <NAME>
-            Show coverage of the specified dependency instead of the crates in the current workspace. (unstable)
+            Show coverage of the specified dependencies (space or comma separated list)
+            instead of the crates in the current workspace.
 
         --skip-functions
             Skip exporting per-function coverage data.
@@ -288,15 +298,14 @@ OPTIONS:
         --target <TRIPLE>
             Build for the target triple
 
-            When this option is used, coverage for proc-macro and build script will not be displayed
-            because cargo does not pass RUSTFLAGS to them.
-
         --coverage-target-only
             Activate coverage reporting only for the target triple
 
             Activate coverage reporting only for the target triple specified via `--target`. This is
             important, if the project uses multiple targets via the cargo bindeps feature, and not
             all targets can use `instrument-coverage`, e.g. a microkernel, or an embedded binary.
+
+            When this flag is used, coverage for proc-macro and build script will not be displayed.
 
     -v, --verbose
             Use verbose output

--- a/docs/cargo-llvm-cov-report.txt
+++ b/docs/cargo-llvm-cov-report.txt
@@ -114,7 +114,8 @@ OPTIONS:
             Include build script in coverage report
 
         --dep-coverage <NAME>
-            Show coverage of the specified dependency instead of the crates in the current workspace. (unstable)
+            Show coverage of the specified dependencies (space or comma separated list)
+            instead of the crates in the current workspace.
 
         --skip-functions
             Skip exporting per-function coverage data.
@@ -154,15 +155,14 @@ OPTIONS:
         --target <TRIPLE>
             Build for the target triple
 
-            When this option is used, coverage for proc-macro and build script will not be displayed
-            because cargo does not pass RUSTFLAGS to them.
-
         --coverage-target-only
             Activate coverage reporting only for the target triple
 
             Activate coverage reporting only for the target triple specified via `--target`. This is
             important, if the project uses multiple targets via the cargo bindeps feature, and not
             all targets can use `instrument-coverage`, e.g. a microkernel, or an embedded binary.
+
+            When this flag is used, coverage for proc-macro and build script will not be displayed.
 
     -v, --verbose
             Use verbose output

--- a/docs/cargo-llvm-cov-run.txt
+++ b/docs/cargo-llvm-cov-run.txt
@@ -103,6 +103,15 @@ OPTIONS:
         --no-clean
             Build without cleaning any old build artifacts
 
+        --no-rustc-wrapper
+            Build without setting RUSTC_WRAPPER
+
+            By default, cargo-llvm-cov sets RUSTC_WRAPPER. This is usually optimal
+            for compilation time, execution time, and disk usage.
+
+            When both this flag and --target option are used, coverage for proc-macro and
+            build script will not be displayed because cargo does not pass RUSTFLAGS to them.
+
         --fail-under-functions <MIN>
             Exit with a status of 1 if the total function coverage is less than MIN percent
 
@@ -128,7 +137,8 @@ OPTIONS:
             Include build script in coverage report
 
         --dep-coverage <NAME>
-            Show coverage of the specified dependency instead of the crates in the current workspace. (unstable)
+            Show coverage of the specified dependencies (space or comma separated list)
+            instead of the crates in the current workspace.
 
         --skip-functions
             Skip exporting per-function coverage data.
@@ -182,15 +192,14 @@ OPTIONS:
         --target <TRIPLE>
             Build for the target triple
 
-            When this option is used, coverage for proc-macro and build script will not be displayed
-            because cargo does not pass RUSTFLAGS to them.
-
         --coverage-target-only
             Activate coverage reporting only for the target triple
 
             Activate coverage reporting only for the target triple specified via `--target`. This is
             important, if the project uses multiple targets via the cargo bindeps feature, and not
             all targets can use `instrument-coverage`, e.g. a microkernel, or an embedded binary.
+
+            When this flag is used, coverage for proc-macro and build script will not be displayed.
 
     -v, --verbose
             Use verbose output

--- a/docs/cargo-llvm-cov-show-env.txt
+++ b/docs/cargo-llvm-cov-show-env.txt
@@ -21,15 +21,14 @@ OPTIONS:
         --target <TRIPLE>
             Build for the target triple
 
-            When this option is used, coverage for proc-macro and build script will not be displayed
-            because cargo does not pass RUSTFLAGS to them.
-
         --coverage-target-only
             Activate coverage reporting only for the target triple
 
             Activate coverage reporting only for the target triple specified via `--target`. This is
             important, if the project uses multiple targets via the cargo bindeps feature, and not
             all targets can use `instrument-coverage`, e.g. a microkernel, or an embedded binary.
+
+            When this flag is used, coverage for proc-macro and build script will not be displayed.
 
         --remap-path-prefix
             Use --remap-path-prefix for workspace root

--- a/docs/cargo-llvm-cov-test.txt
+++ b/docs/cargo-llvm-cov-test.txt
@@ -108,6 +108,15 @@ OPTIONS:
         --no-clean
             Build without cleaning any old build artifacts
 
+        --no-rustc-wrapper
+            Build without setting RUSTC_WRAPPER
+
+            By default, cargo-llvm-cov sets RUSTC_WRAPPER. This is usually optimal
+            for compilation time, execution time, and disk usage.
+
+            When both this flag and --target option are used, coverage for proc-macro and
+            build script will not be displayed because cargo does not pass RUSTFLAGS to them.
+
         --fail-under-functions <MIN>
             Exit with a status of 1 if the total function coverage is less than MIN percent
 
@@ -133,7 +142,8 @@ OPTIONS:
             Include build script in coverage report
 
         --dep-coverage <NAME>
-            Show coverage of the specified dependency instead of the crates in the current workspace. (unstable)
+            Show coverage of the specified dependencies (space or comma separated list)
+            instead of the crates in the current workspace.
 
         --skip-functions
             Skip exporting per-function coverage data.
@@ -238,15 +248,14 @@ OPTIONS:
         --target <TRIPLE>
             Build for the target triple
 
-            When this option is used, coverage for proc-macro and build script will not be displayed
-            because cargo does not pass RUSTFLAGS to them.
-
         --coverage-target-only
             Activate coverage reporting only for the target triple
 
             Activate coverage reporting only for the target triple specified via `--target`. This is
             important, if the project uses multiple targets via the cargo bindeps feature, and not
             all targets can use `instrument-coverage`, e.g. a microkernel, or an embedded binary.
+
+            When this flag is used, coverage for proc-macro and build script will not be displayed.
 
     -v, --verbose
             Use verbose output

--- a/docs/cargo-llvm-cov.txt
+++ b/docs/cargo-llvm-cov.txt
@@ -103,6 +103,15 @@ OPTIONS:
         --no-clean
             Build without cleaning any old build artifacts
 
+        --no-rustc-wrapper
+            Build without setting RUSTC_WRAPPER
+
+            By default, cargo-llvm-cov sets RUSTC_WRAPPER. This is usually optimal
+            for compilation time, execution time, and disk usage.
+
+            When both this flag and --target option are used, coverage for proc-macro and
+            build script will not be displayed because cargo does not pass RUSTFLAGS to them.
+
         --fail-under-functions <MIN>
             Exit with a status of 1 if the total function coverage is less than MIN percent
 
@@ -128,7 +137,8 @@ OPTIONS:
             Include build script in coverage report
 
         --dep-coverage <NAME>
-            Show coverage of the specified dependency instead of the crates in the current workspace. (unstable)
+            Show coverage of the specified dependencies (space or comma separated list)
+            instead of the crates in the current workspace.
 
         --skip-functions
             Skip exporting per-function coverage data.
@@ -236,15 +246,14 @@ OPTIONS:
         --target <TRIPLE>
             Build for the target triple
 
-            When this option is used, coverage for proc-macro and build script will not be displayed
-            because cargo does not pass RUSTFLAGS to them.
-
         --coverage-target-only
             Activate coverage reporting only for the target triple
 
             Activate coverage reporting only for the target triple specified via `--target`. This is
             important, if the project uses multiple targets via the cargo bindeps feature, and not
             all targets can use `instrument-coverage`, e.g. a microkernel, or an embedded binary.
+
+            When this flag is used, coverage for proc-macro and build script will not be displayed.
 
     -v, --verbose
             Use verbose output

--- a/src/clean.rs
+++ b/src/clean.rs
@@ -55,12 +55,17 @@ pub(crate) fn clean_partial(cx: &Context) -> Result<()> {
 
     clean_ws_inner(&cx.ws, &cx.workspace_members.included, cx.args.verbose > 1, false)?;
 
-    let package_args: Vec<_> = cx
-        .workspace_members
-        .included
-        .iter()
-        .flat_map(|id| ["--package", &cx.ws.metadata.packages[id].name])
-        .collect();
+    let mut package_args = Vec::with_capacity(
+        (cx.workspace_members.included.len() + cx.args.cov.dep_coverage.len()) * 2,
+    );
+    for id in &cx.workspace_members.included {
+        package_args.push("--package");
+        package_args.push(&cx.ws.metadata.packages[id].name);
+    }
+    for dep in &cx.args.cov.dep_coverage {
+        package_args.push("--package");
+        package_args.push(dep);
+    }
     let mut cmd = cx.cargo();
     cmd.arg("clean").args(package_args);
     cargo::clean_args(cx, &mut cmd);

--- a/src/context.rs
+++ b/src/context.rs
@@ -69,9 +69,6 @@ impl Context {
             if args.cov.disable_default_ignore_filename_regex {
                 warn!("--disable-default-ignore-filename-regex option is unstable");
             }
-            if args.cov.dep_coverage.is_some() {
-                warn!("--dep-coverage option is unstable");
-            }
             if args.cov.branch {
                 warn!("--branch option is unstable");
             }
@@ -87,10 +84,15 @@ impl Context {
                 warn!("--doctests option is unstable");
             }
         }
-        if args.target.is_some() {
+        if args.coverage_target_only {
             info!(
-                "when --target option is used, coverage for proc-macro and build script will \
-                 not be displayed because cargo does not pass RUSTFLAGS to them"
+                "when --coverage-target-only flag is used, coverage for proc-macro and build script will \
+                 not be displayed"
+            );
+        } else if args.no_rustc_wrapper && args.target.is_some() {
+            info!(
+                "When both --no-rustc-wrapper flag and --target option are used, coverage for proc-macro and \
+                 build script will not be displayed because cargo does not pass RUSTFLAGS to them"
             );
         }
         if !matches!(args.subcommand, Subcommand::Report { .. } | Subcommand::Clean)

--- a/src/env.rs
+++ b/src/env.rs
@@ -3,7 +3,7 @@
 pub(crate) use std::env::*;
 use std::ffi::OsString;
 
-use anyhow::Result;
+use anyhow::{Context as _, Result};
 pub(crate) use cargo_config2::{cargo_home_with_cwd, home_dir, rustup_home_with_cwd};
 
 pub(crate) fn var(key: &str) -> Result<Option<String>> {
@@ -17,4 +17,12 @@ pub(crate) fn var(key: &str) -> Result<Option<String>> {
 
 pub(crate) fn var_os(key: &str) -> Option<OsString> {
     std::env::var_os(key).filter(|v| !v.is_empty())
+}
+
+pub(crate) fn var_required(key: &str) -> Result<String> {
+    var(key).with_context(|| format!("invalid {key}"))?.with_context(|| format!("{key} not set"))
+}
+
+pub(crate) fn var_os_required(key: &str) -> Result<OsString> {
+    var_os(key).with_context(|| format!("{key} not set"))
 }

--- a/src/process.rs
+++ b/src/process.rs
@@ -87,6 +87,10 @@ impl ProcessBuilder {
         self
     }
 
+    pub(crate) fn reserve_exact_args(&mut self, additional: usize) {
+        self.args.reserve_exact(additional);
+    }
+
     /// Set a variable in the process's environment.
     pub(crate) fn env(&mut self, key: impl Into<String>, val: impl Into<OsString>) -> &mut Self {
         self.env.insert(key.into(), Some(val.into()));

--- a/src/wrapper.rs
+++ b/src/wrapper.rs
@@ -1,0 +1,157 @@
+// SPDX-License-Identifier: Apache-2.0 OR MIT
+
+// RUSTC_WRAPPER mode for internal use.
+// Do NOT use this directly since this is an unstable interface.
+
+use anyhow::{Context as _, Result};
+use cargo_config2::Flags;
+use lexopt::Arg::{Long, Short, Value};
+
+use crate::{EnvTarget, cli, context::Context, env, process::ProcessBuilder};
+
+const ENV_ENABLED: &str = "CARGO_LLVM_COV_RUSTC_WRAPPER";
+const ENV_RUSTFLAGS: &str = "CARGO_LLVM_COV_RUSTC_WRAPPER_RUSTFLAGS";
+const ENV_COVERAGE_TARGET: &str = "CARGO_LLVM_COV_RUSTC_WRAPPER_COVERAGE_TARGET";
+const ENV_HOST: &str = "CARGO_LLVM_COV_RUSTC_WRAPPER_HOST";
+const ENV_CRATE_NAMES: &str = "CARGO_LLVM_COV_RUSTC_WRAPPER_CRATE_NAMES";
+const ENV_PRE_EXISTING: &str = "CARGO_LLVM_COV_RUSTC_WRAPPER_PRE_EXISTING";
+
+// -----------------------------------------------------------------------------
+// For caller
+
+pub(crate) fn use_wrapper(cx: &Context) -> bool {
+    if cx.args.no_rustc_wrapper {
+        // Explicitly disabled.
+        return false;
+    }
+    true
+}
+
+pub(crate) fn set_env(cx: &Context, env: &mut dyn EnvTarget, rustflags: &Flags) -> Result<()> {
+    if !use_wrapper(cx) {
+        // Handle nested calls.
+        if env::var_os(ENV_ENABLED).is_some() {
+            if let Some(pre_existing_wrapper) = env::var_os(ENV_PRE_EXISTING) {
+                env.set_os("RUSTC_WRAPPER", &pre_existing_wrapper)?;
+            } else {
+                env.unset("RUSTC_WRAPPER")?;
+            }
+        }
+        return Ok(());
+    }
+
+    env.set(ENV_ENABLED, "1")?;
+    env.set(ENV_RUSTFLAGS, &rustflags.encode()?)?;
+    match (cx.args.coverage_target_only, &cx.args.target) {
+        (true, Some(coverage_target)) => {
+            env.set(ENV_COVERAGE_TARGET, coverage_target)?;
+            env.set(ENV_HOST, cx.ws.config.host_triple()?)?;
+        }
+        _ => {
+            env.unset(ENV_COVERAGE_TARGET)?;
+            env.unset(ENV_HOST)?;
+        }
+    }
+    let mut crates = String::new();
+    for id in &cx.ws.metadata.workspace_members {
+        let pkg = &cx.ws.metadata.packages[id];
+        let name = &pkg.name.replace('-', "_");
+        crates.push_str(name);
+        crates.push(',');
+        crates.push_str(name);
+        crates.push_str("_tests,"); // for try_build
+        for target in &pkg.targets {
+            crates.push_str(&target.name.replace('-', "_"));
+            crates.push(',');
+        }
+    }
+    for dep in &cx.args.cov.dep_coverage {
+        let name = &dep.replace('-', "_");
+        // TODO: should refer the lib name.
+        crates.push_str(name);
+        crates.push(',');
+    }
+    crates.pop(); // drop trailing coma
+    env.set(ENV_CRATE_NAMES, &crates)?;
+    env.set_os("RUSTC_WRAPPER", cx.current_exe.as_os_str())?;
+    if let Some(pre_existing_wrapper) = cx.ws.config.build.rustc_wrapper.as_deref() {
+        env.set_os(ENV_PRE_EXISTING, pre_existing_wrapper.as_os_str())?;
+    } else {
+        env.unset(ENV_PRE_EXISTING)?;
+    }
+    Ok(())
+}
+
+// -----------------------------------------------------------------------------
+// For callee
+
+pub(crate) fn is_enabled() -> bool {
+    if env::var_os(ENV_ENABLED).is_none() {
+        return false;
+    }
+    let mut args = env::args_os();
+    args.next(); // cargo or cargo-llvm-cov
+    let Some(first) = args.next() else { return false };
+    if first == cli::FIRST_SUBCMD {
+        // Handle nested calls.
+        // In show-env context, CARGO_LLVM_COV_RUSTC_WRAPPER may be set for
+        // other subcommands. For example, a situation where a process to
+        // generate a report is expected despite CARGO_LLVM_COV_RUSTC_WRAPPER
+        // being set may occur.
+        return false;
+    }
+    true
+}
+
+pub(crate) fn try_main() -> Result<()> {
+    // Fetch context from env vars.
+    debug_assert!(is_enabled());
+    let wrapper_rustflags = Flags::from_encoded(&env::var_required(ENV_RUSTFLAGS)?).flags;
+    let coverage_target = env::var_os(ENV_COVERAGE_TARGET);
+    let host = if coverage_target.is_some() { Some(env::var_os_required(ENV_HOST)?) } else { None };
+    let crate_names = env::var_required(ENV_CRATE_NAMES)?;
+    let crate_names = crate_names.split(',').collect::<Vec<_>>();
+    let pre_existing_wrapper = env::var_os(ENV_PRE_EXISTING);
+
+    // Parse arguments.
+    let mut raw_args = env::args_os();
+    raw_args.next(); // cargo-llvm-cov
+    let rustc_or_wrapper = if let Some(pre_existing_wrapper) = pre_existing_wrapper {
+        // pre-existing rustc-wrapper
+        pre_existing_wrapper
+    } else {
+        // rustc or rustc-workspace-wrapper
+        raw_args.next().context("invalid arguments for rustc-wrapper")?
+    };
+    let args = raw_args.collect::<Vec<_>>();
+    let mut crate_name = None;
+    let mut target = None;
+    let mut parser = lexopt::Parser::from_args(&args);
+    while let Some(arg) = parser.next()? {
+        match arg {
+            Long("crate-name") => crate_name = Some(parser.value()?),
+            Long("target") => target = Some(parser.value()?),
+            Long(_) | Short(_) => {
+                parser.optional_value();
+            }
+            Value(_) => {}
+        }
+    }
+
+    // Run rustc or wrapper.
+    let mut cmd = ProcessBuilder::new(rustc_or_wrapper);
+    // Skip cases where no crate name specified, e.g., --version, --print.
+    let apply_wrapper_rustflags = crate_name
+        .is_some_and(|crate_name| crate_names.iter().any(|&name| name == crate_name))
+        && coverage_target
+            .is_none_or(|coverage_target| coverage_target == target.unwrap_or(host.unwrap()));
+    cmd.reserve_exact_args(
+        args.len() + if apply_wrapper_rustflags { wrapper_rustflags.len() } else { 0 },
+    );
+    cmd.args(args);
+    if apply_wrapper_rustflags {
+        cmd.args(wrapper_rustflags);
+    }
+    cmd.run()?;
+    Ok(())
+}

--- a/tests/test.rs
+++ b/tests/test.rs
@@ -335,8 +335,10 @@ fn show_env() {
         .env("CARGO_ENCODED_RUSTFLAGS", flags)
         .arg("--with-pwsh-env-prefix")
         .assert_success()
-        // Verify the prefix related content + the encoding of "--"
-        .stdout_contains("$env:CARGO_ENCODED_RUSTFLAGS=\"`u{2d}`u{2d}")
+        .stdout_not_contains("$env:CARGO_ENCODED_RUSTFLAGS=")
+        .stdout_not_contains("$env:RUSTFLAGS=")
+        // Verify the prefix related content + the encoding of "-"
+        .stdout_contains("$env:CARGO_LLVM_COV_RUSTC_WRAPPER_RUSTFLAGS=\"`u{2d}")
         // Verify binary character didn't lead to incompatible output for pwsh
         .stdout_contains("`u{1f}");
     cargo_llvm_cov("show-env")


### PR DESCRIPTION
Closes https://github.com/taiki-e/cargo-llvm-cov/issues/447
Closes https://github.com/taiki-e/cargo-llvm-cov/issues/387

- This expected to improve compilation time, execution time, and disk usage. See the above issues for more.
  cc https://github.com/taiki-e/cargo-llvm-cov/issues/376 https://github.com/taiki-e/cargo-llvm-cov/issues/371 https://github.com/taiki-e/cargo-llvm-cov/issues/335 https://github.com/taiki-e/cargo-llvm-cov/issues/456 https://github.com/taiki-e/cargo-llvm-cov/issues/417 https://github.com/taiki-e/cargo-llvm-cov/issues/284

- Coverage for proc-macro and build script is now supported even with cross-compile by default.

- This also improves and stabilizes the `--dep-coverage` option. Specifying multiple crate names (space or comma separated list) is now accepted.

- `RUSTFLAGS` no longer set by default; this removes the need of workaround for https://github.com/taiki-e/cargo-llvm-cov/issues/332 and may affect for https://github.com/taiki-e/cargo-llvm-cov/issues/212

- cfgs no longer set for dependencies by default; this removes the need of workaround for https://github.com/taiki-e/cargo-llvm-cov/issues/455

- Can be disabled this behavior by using `--no-rustc-wrapper` flag.
