### PR TITLE
show-env: Add --sh (alias of --export-prefix), --pwsh (alias of --with-pwsh-env-prefix), --cmd, --fish

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -207,6 +207,140 @@ jobs:
       - run: cargo minimal-versions build --workspace --no-private --detach-path-deps=skip-exact --all-features
         # TODO(windows-gnullvm): winapi 0.3.5 (dep of old version of termcolor)
         if: matrix.target != 'aarch64-pc-windows-gnullvm'
+      - name: Test show-env --sh on bash
+        run: |
+          bash --version
+          if [[ "${{ matrix.os }}" == "macos"* ]]; then
+            # macOS's /bin/bash is too old.
+            cargo llvm-cov show-env --sh > env.sh
+            # shellcheck disable=SC1091
+            . ./env.sh
+          else
+            # shellcheck disable=SC1090
+            source <(cargo llvm-cov show-env --sh)
+          fi
+          cargo llvm-cov clean --workspace
+          cargo build
+          cargo run -- 1
+          cargo llvm-cov report --fail-under-lines 50
+          cargo llvm-cov clean --workspace
+          cargo build
+          cargo run -- 2
+          cargo llvm-cov report --fail-under-lines 50
+        working-directory: tests/fixtures/crates/bin_crate
+      - name: Test show-env --sh on sh
+        run: |
+          set -eux
+          cargo llvm-cov show-env --sh > env.sh
+          # shellcheck disable=SC1091
+          . ./env.sh
+          cargo llvm-cov clean --workspace
+          cargo build
+          cargo run -- 1
+          cargo llvm-cov report --fail-under-lines 50
+          cargo llvm-cov clean --workspace
+          cargo build
+          cargo run -- 2
+          cargo llvm-cov report --fail-under-lines 50
+        shell: sh
+        working-directory: tests/fixtures/crates/bin_crate
+        if: startsWith(matrix.os, 'ubuntu') || matrix.os == '' || startsWith(matrix.os, 'macos')
+      - name: Test show-env --pwsh on pwsh
+        run: |
+          pwsh --version
+          Invoke-Expression (cargo llvm-cov show-env --pwsh | Out-String)
+          env
+          cargo llvm-cov clean --workspace
+          cargo build
+          cargo run -- 1
+          cargo llvm-cov report --fail-under-lines 50
+          cargo llvm-cov clean --workspace
+          cargo build
+          cargo run -- 2
+          cargo llvm-cov report --fail-under-lines 50
+        shell: pwsh
+        working-directory: tests/fixtures/crates/bin_crate
+      # TODO: --pwsh currently supports PowerShell 6+
+      # - name: Test show-env --pwsh on powershell
+      #   run: |
+      #     $PSVersionTable.PSVersion
+      #     $PSDefaultParameterValues['*:Encoding'] = 'utf8'
+      #     Invoke-Expression (cargo llvm-cov show-env --pwsh | Out-String)
+      #     env
+      #     cargo llvm-cov clean --workspace
+      #     cargo build
+      #     cargo run -- 1
+      #     cargo llvm-cov report --fail-under-lines 50
+      #     cargo llvm-cov clean --workspace
+      #     cargo build
+      #     cargo run -- 2
+      #     cargo llvm-cov report --fail-under-lines 50
+      #   shell: powershell
+      #   working-directory: tests/fixtures/crates/bin_crate
+      #   if: startsWith(matrix.os, 'windows')
+      - name: Test show-env --cmd
+        run: |
+          cargo llvm-cov show-env --cmd > env.bat
+          call env.bat
+          env
+          cargo llvm-cov clean --workspace
+          cargo build
+          cargo run -- 1
+          cargo llvm-cov report --fail-under-lines 50
+          cargo llvm-cov clean --workspace
+          cargo build
+          cargo run -- 2
+          cargo llvm-cov report --fail-under-lines 50
+        shell: cmd
+        working-directory: tests/fixtures/crates/bin_crate
+        if: startsWith(matrix.os, 'windows')
+      - name: Install other shells (Ubuntu)
+        run: |
+          sudo apt-get -o Acquire::Retries=10 -qq update
+          sudo apt-get -o Acquire::Retries=10 -o Dpkg::Use-Pty=0 install -y --no-install-recommends fish zsh
+        if: startsWith(matrix.os, 'ubuntu') || matrix.os == ''
+      - name: Install other shells (macOS)
+        run: |
+          brew install fish
+        if: startsWith(matrix.os, 'macos')
+      - name: Install other shells (Windows)
+        run: |
+          C:/msys64/usr/bin/pacman -S --noconfirm fish zsh
+          printf '%s\n' 'C:\msys64\usr\bin' >>"${GITHUB_PATH}"
+        # TODO: C:/msys64/usr/bin/pacman: No such file or directory
+        if: startsWith(matrix.os, 'windows') && matrix.os != 'windows-11-arm'
+      - name: Test show-env --sh on zsh
+        run: |
+          set -eux
+          zsh --version
+          source <(cargo llvm-cov show-env --sh)
+          cargo llvm-cov clean --workspace
+          cargo build
+          cargo run -- 1
+          cargo llvm-cov report --fail-under-lines 50
+          cargo llvm-cov clean --workspace
+          cargo build
+          cargo run -- 2
+          cargo llvm-cov report --fail-under-lines 50
+        shell: zsh {0}
+        working-directory: tests/fixtures/crates/bin_crate
+        if: matrix.os != 'windows-11-arm'
+      - name: Test show-env --fish
+        run: |
+          cargo llvm-cov show-env --sh > env.fish
+          cat -- env.fish
+          source env.fish
+          cargo llvm-cov clean --workspace
+          cargo build
+          cargo run -- 1
+          cargo llvm-cov report --fail-under-lines 50
+          cargo llvm-cov clean --workspace
+          cargo build
+          cargo run -- 2
+          cargo llvm-cov report --fail-under-lines 50
+        shell: fish {0}
+        working-directory: tests/fixtures/crates/bin_crate
+        if: matrix.os != 'windows-11-arm'
 
   test-llvm:
     strategy:
@@ -247,8 +381,7 @@ jobs:
           codename=$(grep -E '^VERSION_CODENAME=' /etc/os-release | cut -d= -f2)
           sudo mkdir -pm755 -- /etc/apt/keyrings
           retry curl --proto '=https' --tlsv1.2 -fsSL --retry 10 --retry-connrefused https://apt.llvm.org/llvm-snapshot.gpg.key \
-            | gpg --dearmor \
-            | sudo tee -- /etc/apt/keyrings/llvm-snapshot.gpg >/dev/null
+            | sudo gpg --dearmor -o /etc/apt/keyrings/llvm-snapshot.gpg >/dev/null
           sudo tee -- "/etc/apt/sources.list.d/llvm-toolchain-${codename}-${{ matrix.llvm }}.list" >/dev/null \
             <<<"deb [signed-by=/etc/apt/keyrings/llvm-snapshot.gpg] http://apt.llvm.org/${codename}/ llvm-toolchain-${codename}-${{ matrix.llvm }} main"
           retry sudo apt-get -o Acquire::Retries=10 -qq update

--- a/.github/zizmor.yml
+++ b/.github/zizmor.yml
@@ -10,3 +10,7 @@ rules:
       policies:
         taiki-e/*: any
         '*': ref-pin
+  misfeature:
+    ignore:
+      # We use `shell: cmd` to test compatibility.
+      - ci.yml

--- a/README.md
+++ b/README.md
@@ -476,7 +476,7 @@ Known compatible Rust (installed via rustup) and LLVM versions:
 
 ```sh
 # Set the environment variables needed to get coverage.
-source <(cargo llvm-cov show-env --export-prefix)
+source <(cargo llvm-cov show-env --sh)
 # Remove artifacts that may affect the coverage results.
 # This command should be called after show-env.
 cargo llvm-cov clean --workspace
@@ -499,8 +499,11 @@ cargo llvm-cov report --lcov # Generate report without tests.
 > The same thing can be achieved in PowerShell 6+ by substituting the source command with:
 >
 > ```powershell
-> Invoke-Expression (cargo llvm-cov show-env --with-pwsh-env-prefix | Out-String)
+> Invoke-Expression (cargo llvm-cov show-env --pwsh | Out-String)
 > ```
+>
+> See "Test show-env ... on ..." in [our CI config](https://github.com/taiki-e/cargo-llvm-cov/blob/HEAD/.github/workflows/ci.yml)
+> for usage with other shells.
 
 ### Get coverage of AFL fuzzers
 
@@ -508,7 +511,7 @@ Cargo-llvm-cov can be used with [AFL.rs](https://github.com/rust-fuzz/afl.rs) si
 
 ```sh
 # Set environment variables and clean workspace
-source <(cargo llvm-cov show-env --export-prefix)
+source <(cargo llvm-cov show-env --sh)
 cargo llvm-cov clean --workspace
 # Build the fuzz target
 cargo afl build

--- a/docs/cargo-llvm-cov-show-env.txt
+++ b/docs/cargo-llvm-cov-show-env.txt
@@ -5,12 +5,17 @@ USAGE:
     cargo llvm-cov show-env [OPTIONS]
 
 OPTIONS:
-        --export-prefix
-            Prepend "export " to each line, so that the output is suitable to be sourced by bash
+        --sh, --export-prefix
+            Make output suitable to be sourced by POSIX sh, Bash, and Zsh
 
-        --with-pwsh-env-prefix
-            Unicode escape and double quote values + prepend "$env:", so that the output is suitable
-            to be used with Invoke-Expression in PowerShell 6+.
+        --pwsh, --with-pwsh-env-prefix
+            Make output suitable to be used with Invoke-Expression in PowerShell 6+
+
+        --cmd
+            Make output suitable to be called by cmd.exe
+
+        --fish
+            Make output suitable to be sourced by fish
 
         --doctests
             Including doc tests (unstable)


### PR DESCRIPTION
Unify flag names, add support for cmd.exe and fish, and added tests.

```text
        --sh, --export-prefix
            Make output suitable to be sourced by POSIX sh, Bash, and Zsh

        --pwsh, --with-pwsh-env-prefix
            Make output suitable to be used with Invoke-Expression in PowerShell 6+

        --cmd
            Make output suitable to be called by cmd.exe

        --fish
            Make output suitable to be sourced by fish
```