### PR TITLE
Add --include-filename-regex option

### DIFF
--- a/README.md
+++ b/README.md
@@ -139,6 +139,9 @@ OPTIONS:
         --ignore-filename-regex <PATTERN>
             Skip source code files with file paths that match the given regular expression
 
+        --include-filename-regex <PATTERN>
+            Only include source code files with file paths that match the given regular expression
+
         --show-instantiations
             Show instantiations in report
 

--- a/docs/cargo-llvm-cov-report.txt
+++ b/docs/cargo-llvm-cov-report.txt
@@ -86,6 +86,9 @@ OPTIONS:
         --ignore-filename-regex <PATTERN>
             Skip source code files with file paths that match the given regular expression
 
+        --include-filename-regex <PATTERN>
+            Only include source code files with file paths that match the given regular expression
+
         --show-instantiations
             Show instantiations in report
 

--- a/docs/cargo-llvm-cov-run.txt
+++ b/docs/cargo-llvm-cov-run.txt
@@ -87,6 +87,9 @@ OPTIONS:
         --ignore-filename-regex <PATTERN>
             Skip source code files with file paths that match the given regular expression
 
+        --include-filename-regex <PATTERN>
+            Only include source code files with file paths that match the given regular expression
+
         --show-instantiations
             Show instantiations in report
 

--- a/docs/cargo-llvm-cov-test.txt
+++ b/docs/cargo-llvm-cov-test.txt
@@ -92,6 +92,9 @@ OPTIONS:
         --ignore-filename-regex <PATTERN>
             Skip source code files with file paths that match the given regular expression
 
+        --include-filename-regex <PATTERN>
+            Only include source code files with file paths that match the given regular expression
+
         --show-instantiations
             Show instantiations in report
 

--- a/docs/cargo-llvm-cov.txt
+++ b/docs/cargo-llvm-cov.txt
@@ -87,6 +87,9 @@ OPTIONS:
         --ignore-filename-regex <PATTERN>
             Skip source code files with file paths that match the given regular expression
 
+        --include-filename-regex <PATTERN>
+            Only include source code files with file paths that match the given regular expression
+
         --show-instantiations
             Show instantiations in report
 

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -308,6 +308,8 @@ pub(crate) struct ReportOptions {
     pub(crate) failure_mode: Option<String>,
     /// Skip source code files with file paths that match the given regular expression.
     pub(crate) ignore_filename_regex: Option<String>,
+    /// Only include source code files with file paths that match the given regular expression.
+    pub(crate) include_filename_regex: Option<String>,
     // For debugging (unstable)
     pub(crate) no_default_ignore_filename_regex: bool,
     /// Show instantiations in report
@@ -369,6 +371,7 @@ impl ReportOptions {
                 output_dir,
                 failure_mode,
                 ignore_filename_regex,
+                include_filename_regex,
                 no_default_ignore_filename_regex,
                 show_instantiations,
                 fail_under_functions,
@@ -394,6 +397,7 @@ impl ReportOptions {
                 ("--output-dir", output_dir.is_some()),
                 ("--failure-mode", failure_mode.is_some()),
                 ("--ignore-filename-regex", ignore_filename_regex.is_some()),
+                ("--include-filename-regex", include_filename_regex.is_some()),
                 ("--no-default-ignore-filename-regex", *no_default_ignore_filename_regex),
                 ("--show-instantiations", *show_instantiations),
                 ("--fail-under-functions", fail_under_functions.is_some()),
@@ -1083,6 +1087,7 @@ impl Args {
                 Long("output-dir") => parse_opt!(report.output_dir),
                 Long("failure-mode") => parse_opt!(report.failure_mode),
                 Long("ignore-filename-regex") => parse_opt!(report.ignore_filename_regex),
+                Long("include-filename-regex") => parse_opt!(report.include_filename_regex),
                 Long(
                     flag @ ("no-default-ignore-filename-regex"
                     | "disable-default-ignore-filename-regex"),
@@ -1501,6 +1506,7 @@ impl Args {
         // forbid_empty_values
         for (flag, is_empty) in [
             ("--ignore-filename-regex", report.ignore_filename_regex.as_deref() == Some("")),
+            ("--include-filename-regex", report.include_filename_regex.as_deref() == Some("")),
             ("--output-path", report.output_path.as_deref() == Some(Utf8Path::new(""))),
             ("--output-dir", report.output_dir.as_deref() == Some(Utf8Path::new(""))),
         ] {

--- a/src/json.rs
+++ b/src/json.rs
@@ -72,7 +72,11 @@ pub struct CodeCovJsonExport {
 }
 
 impl CodeCovJsonExport {
-    fn from_export(value: Export, ignore_filename_regex: Option<&Regex>) -> Self {
+    fn from_export(
+        value: Export,
+        ignore_filename_regex: Option<&Regex>,
+        include_filename_regex: Option<&Regex>,
+    ) -> Self {
         let functions = value.functions.unwrap_or_default();
 
         let mut regions = HashMap::new();
@@ -81,6 +85,11 @@ impl CodeCovJsonExport {
             for filename in func.filenames {
                 if let Some(re) = ignore_filename_regex {
                     if re.is_match(&filename) {
+                        continue;
+                    }
+                }
+                if let Some(re) = include_filename_regex {
+                    if !re.is_match(&filename) {
                         continue;
                     }
                 }
@@ -118,9 +127,14 @@ impl CodeCovJsonExport {
     pub fn from_llvm_cov_json_export(
         value: LlvmCovJsonExport,
         ignore_filename_regex: Option<&str>,
+        include_filename_regex: Option<&str>,
     ) -> Self {
-        let re = ignore_filename_regex.map(|s| Regex::new(s).unwrap());
-        let exports = value.data.into_iter().map(|v| Self::from_export(v, re.as_ref()));
+        let ignore_re = ignore_filename_regex.map(|s| Regex::new(s).unwrap());
+        let include_re = include_filename_regex.map(|s| Regex::new(s).unwrap());
+        let exports = value
+            .data
+            .into_iter()
+            .map(|v| Self::from_export(v, ignore_re.as_ref(), include_re.as_ref()));
 
         let mut combined = CodeCovJsonExport::default();
 
@@ -204,10 +218,15 @@ impl LlvmCovJsonExport {
 
     /// Gets the list of uncovered lines of all files.
     #[must_use]
-    pub fn get_uncovered_lines(&self, ignore_filename_regex: Option<&str>) -> UncoveredLines {
+    pub fn get_uncovered_lines(
+        &self,
+        ignore_filename_regex: Option<&str>,
+        include_filename_regex: Option<&str>,
+    ) -> UncoveredLines {
         let mut uncovered_files: UncoveredLines = BTreeMap::new();
         let mut covered_files: UncoveredLines = BTreeMap::new();
-        let re = ignore_filename_regex.map(|s| Regex::new(s).unwrap());
+        let ignore_re = ignore_filename_regex.map(|s| Regex::new(s).unwrap());
+        let include_re = include_filename_regex.map(|s| Regex::new(s).unwrap());
         for data in &self.data {
             if let Some(ref functions) = data.functions {
                 // Iterate over all functions inside the coverage data.
@@ -216,8 +235,13 @@ impl LlvmCovJsonExport {
                         continue;
                     }
                     let file_name = &function.filenames[0];
-                    if let Some(ref re) = re {
+                    if let Some(ref re) = ignore_re {
                         if re.is_match(file_name) {
+                            continue;
+                        }
+                    }
+                    if let Some(ref re) = include_re {
+                        if !re.is_match(file_name) {
                             continue;
                         }
                     }
@@ -634,7 +658,7 @@ mod tests {
 
         // When finding uncovered lines in that report:
         let ignore_filename_regex = None;
-        let uncovered_lines = json.get_uncovered_lines(ignore_filename_regex);
+        let uncovered_lines = json.get_uncovered_lines(ignore_filename_regex, None);
 
         // Then make sure the file / line data matches the `llvm-cov report` output:
         let expected: UncoveredLines =
@@ -655,7 +679,7 @@ mod tests {
         let json = serde_json::from_str::<LlvmCovJsonExport>(&s).unwrap();
 
         let ignore_filename_regex = None;
-        let uncovered_lines = json.get_uncovered_lines(ignore_filename_regex);
+        let uncovered_lines = json.get_uncovered_lines(ignore_filename_regex, None);
 
         let expected: UncoveredLines = UncoveredLines::new();
         assert_eq!(uncovered_lines, expected);
@@ -674,7 +698,7 @@ mod tests {
 
         // When finding uncovered lines in that report:
         let ignore_filename_regex = None;
-        let uncovered_lines = json.get_uncovered_lines(ignore_filename_regex);
+        let uncovered_lines = json.get_uncovered_lines(ignore_filename_regex, None);
 
         // Then make sure the file / line data matches the `llvm-cov report` output:
         let expected: UncoveredLines =
@@ -684,5 +708,23 @@ mod tests {
         //    covered, which should be presented as a "covered" 11th line.
         // 2) only the last function with missing lines were reported, so 15 and 17 was missing.
         assert_eq!(uncovered_lines, expected);
+    }
+
+    #[test]
+    fn test_get_uncovered_lines_include_filename_regex() {
+        let file = format!("{}/tests/fixtures/show-missing-lines.json", env!("CARGO_MANIFEST_DIR"));
+        let s = fs::read_to_string(file).unwrap();
+
+        // When include regex matches the file, uncovered lines are reported.
+        let json = serde_json::from_str::<LlvmCovJsonExport>(&s).unwrap();
+        let uncovered_lines = json.get_uncovered_lines(None, Some("src/lib\\.rs"));
+        let expected: UncoveredLines =
+            vec![("src/lib.rs".to_owned(), vec![7, 8, 9])].into_iter().collect();
+        assert_eq!(uncovered_lines, expected);
+
+        // When include regex does not match any file, no uncovered lines are reported.
+        let json = serde_json::from_str::<LlvmCovJsonExport>(&s).unwrap();
+        let uncovered_lines = json.get_uncovered_lines(None, Some("src/file_does_not_exists\\.rs"));
+        assert_eq!(uncovered_lines, UncoveredLines::new());
     }
 }

--- a/src/report.rs
+++ b/src/report.rs
@@ -109,7 +109,10 @@ pub(crate) fn generate(cx: &Context) -> Result<()> {
         }
         if let Some(fail_uncovered_lines) = cx.args.report.fail_uncovered_lines {
             // Handle --fail-uncovered-lines.
-            let uncovered_files = json.get_uncovered_lines(ignore_filename_regex.as_deref());
+            let uncovered_files = json.get_uncovered_lines(
+                ignore_filename_regex.as_deref(),
+                cx.args.report.include_filename_regex.as_deref(),
+            );
             let uncovered = uncovered_files
                 .iter()
                 .fold(0_u64, |uncovered, (_, lines)| uncovered + lines.len() as u64);
@@ -129,7 +132,10 @@ pub(crate) fn generate(cx: &Context) -> Result<()> {
 
         if cx.args.report.show_missing_lines {
             // Handle --show-missing-lines.
-            let uncovered_files = json.get_uncovered_lines(ignore_filename_regex.as_deref());
+            let uncovered_files = json.get_uncovered_lines(
+                ignore_filename_regex.as_deref(),
+                cx.args.report.include_filename_regex.as_deref(),
+            );
             if !uncovered_files.is_empty() {
                 let mut stdout = BufWriter::new(io::stdout().lock()); // Buffered because it is written with newline many times.
                 writeln!(stdout, "Uncovered Lines:")?;
@@ -636,6 +642,10 @@ impl ReportFormat {
             cmd.arg("-ignore-filename-regex");
             cmd.arg(ignore_filename_regex);
         }
+        if let Some(include_filename_regex) = &cx.args.report.include_filename_regex {
+            cmd.arg("-include-filename-regex");
+            cmd.arg(include_filename_regex);
+        }
 
         match self {
             Self::Text | Self::Html => {
@@ -715,7 +725,11 @@ impl ReportFormat {
             }
             let cov = cmd.read()?;
             let cov: LlvmCovJsonExport = serde_json::from_str(&cov)?;
-            let cov = CodeCovJsonExport::from_llvm_cov_json_export(cov, ignore_filename_regex);
+            let cov = CodeCovJsonExport::from_llvm_cov_json_export(
+                cov,
+                ignore_filename_regex,
+                cx.args.report.include_filename_regex.as_deref(),
+            );
             let out = serde_json::to_string(&cov)?;
 
             if let Some(output_path) = &cx.args.report.output_path {
@@ -796,6 +810,10 @@ impl ReportFormat {
         if let Some(ignore_filename_regex) = ignore_filename_regex {
             cmd.arg("-ignore-filename-regex");
             cmd.arg(ignore_filename_regex);
+        }
+        if let Some(include_filename_regex) = &cx.args.report.include_filename_regex {
+            cmd.arg("-include-filename-regex");
+            cmd.arg(include_filename_regex);
         }
         if term::verbose() {
             status!("Running", "{cmd}");


### PR DESCRIPTION
Fixes: #478

Adds the `--include-filename-regex` (is supported by [`llvm-cov show -include-filename-regex=<PATTERN>`](https://llvm.org/docs/CommandGuide/llvm-cov.html#cmdoption-llvm-cov-show-include-filename-regex) and some manual additions for other file formats.
Implementation details inspired by `--ignore-filename-regex` to make sure code is similar.
One test added to cover the basic 2 case.

Note: This code is created with support of LLM. All code was manually reviews by me.