### PR TITLE
Ask to run `rustup install` on `stderr`

### DIFF
--- a/src/context.rs
+++ b/src/context.rs
@@ -561,8 +561,8 @@ fn ask_to_run(cmd: &ProcessBuilder, ask: bool, text: &str) -> Result<()> {
     let is_ci = env::var_os("CI").is_some() || env::var_os("TF_BUILD").is_some();
     if ask && !is_ci {
         let mut buf = String::new();
-        print!("I will run {cmd} to {text}.\nProceed? [Y/n] ");
-        io::stdout().flush()?;
+        eprint!("I will run {cmd} to {text}.\nProceed? [Y/n] ");
+        io::stderr().flush()?;
         io::stdin().read_line(&mut buf)?;
         match buf.trim().to_lowercase().as_str() {
             // Proceed.


### PR DESCRIPTION
When `stdout` is not visible, e. g. when piping the output of `cargo llvm-cov` to a file, it seems like `cargo llvm-cov` hangs without doing anything when the `llvm-tools-preview` rustup component is not installed. `stderr` is less likely to be redirected, so asking on there is less likely to not be visible.