### PR TITLE
Remove create_dirs_for_build

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -82,27 +82,23 @@ fn try_main() -> Result<()> {
         Subcommand::Run => {
             let cx = &Context::new(args)?;
             clean::clean_partial(cx)?;
-            create_dirs_for_build(cx)?;
             run_run(cx)?;
             report::generate(cx)?;
         }
         Subcommand::Nextest { .. } => {
             let cx = &Context::new(args)?;
             clean::clean_partial(cx)?;
-            create_dirs_for_build(cx)?;
             run_nextest(cx)?;
             report::generate(cx)?;
         }
         Subcommand::NextestArchive => {
             let cx = &Context::new(args)?;
             clean::clean_partial(cx)?;
-            create_dirs_for_build(cx)?;
             archive_nextest(cx)?;
         }
         Subcommand::None | Subcommand::Test => {
             let cx = &Context::new(args)?;
             clean::clean_partial(cx)?;
-            create_dirs_for_build(cx)?;
             run_test(cx)?;
             report::generate(cx)?;
         }
@@ -350,14 +346,6 @@ fn set_env(cx: &Context, env: &mut dyn EnvTarget, IsNextest(is_nextest): IsNexte
     env.set("CARGO_LLVM_COV", "1")?;
     if cx.args.subcommand == Subcommand::ShowEnv {
         env.set("CARGO_LLVM_COV_SHOW_ENV", "1")?;
-    }
-    Ok(())
-}
-
-fn create_dirs_for_build(cx: &Context) -> Result<()> {
-    fs::create_dir_all(&cx.ws.target_dir)?;
-    if cx.args.doctests {
-        fs::create_dir_all(&cx.ws.doctests_dir)?;
     }
     Ok(())
 }


### PR DESCRIPTION
Since https://github.com/rust-lang/cargo/pull/16712, it seems that cargo requires that the target directory be one that cargo have created.

```
warning: process didn't exit successfully: `/home/runner/.rustup/toolchains/nightly-x86_64-unknown-linux-gnu/bin/cargo clean --target-dir /tmp/.tmpVKxu0N/target/llvm-cov-target --package merge` (exit status: 101)
--- stderr
error: cannot clean `/tmp/.tmpVKxu0N/target/llvm-cov-target`: missing or invalid `CACHEDIR.TAG` file
  |
  = note: cleaning has been aborted to prevent accidental deletion of unrelated files
```