### PR TITLE
add `--coverage-host-only` flag

### DIFF
--- a/README.md
+++ b/README.md
@@ -313,6 +313,13 @@ OPTIONS:
 
             When this flag is used, coverage for proc-macro and build script will not be displayed.
 
+        --coverage-host-only
+            Activate coverage reporting only for the host target triple
+
+            In cross-compilation builds, this can be used to get coverage for build scripts and
+            proc-macro while skipping coverage for the cross-compiled target which may not support
+            `instrument-coverage`.
+
     -v, --verbose
             Use verbose output
 

--- a/docs/cargo-llvm-cov-report.txt
+++ b/docs/cargo-llvm-cov-report.txt
@@ -167,6 +167,13 @@ OPTIONS:
 
             When this flag is used, coverage for proc-macro and build script will not be displayed.
 
+        --coverage-host-only
+            Activate coverage reporting only for the host target triple
+
+            In cross-compilation builds, this can be used to get coverage for build scripts and
+            proc-macro while skipping coverage for the cross-compiled target which may not support
+            `instrument-coverage`.
+
     -v, --verbose
             Use verbose output
 

--- a/docs/cargo-llvm-cov-run.txt
+++ b/docs/cargo-llvm-cov-run.txt
@@ -207,6 +207,13 @@ OPTIONS:
 
             When this flag is used, coverage for proc-macro and build script will not be displayed.
 
+        --coverage-host-only
+            Activate coverage reporting only for the host target triple
+
+            In cross-compilation builds, this can be used to get coverage for build scripts and
+            proc-macro while skipping coverage for the cross-compiled target which may not support
+            `instrument-coverage`.
+
     -v, --verbose
             Use verbose output
 

--- a/docs/cargo-llvm-cov-show-env.txt
+++ b/docs/cargo-llvm-cov-show-env.txt
@@ -44,6 +44,13 @@ OPTIONS:
 
             When this flag is used, coverage for proc-macro and build script will not be displayed.
 
+        --coverage-host-only
+            Activate coverage reporting only for the host target triple
+
+            In cross-compilation builds, this can be used to get coverage for build scripts and
+            proc-macro while skipping coverage for the cross-compiled target which may not support
+            `instrument-coverage`.
+
         --remap-path-prefix
             Use --remap-path-prefix for workspace root
 

--- a/docs/cargo-llvm-cov-test.txt
+++ b/docs/cargo-llvm-cov-test.txt
@@ -263,6 +263,13 @@ OPTIONS:
 
             When this flag is used, coverage for proc-macro and build script will not be displayed.
 
+        --coverage-host-only
+            Activate coverage reporting only for the host target triple
+
+            In cross-compilation builds, this can be used to get coverage for build scripts and
+            proc-macro while skipping coverage for the cross-compiled target which may not support
+            `instrument-coverage`.
+
     -v, --verbose
             Use verbose output
 

--- a/docs/cargo-llvm-cov.txt
+++ b/docs/cargo-llvm-cov.txt
@@ -261,6 +261,13 @@ OPTIONS:
 
             When this flag is used, coverage for proc-macro and build script will not be displayed.
 
+        --coverage-host-only
+            Activate coverage reporting only for the host target triple
+
+            In cross-compilation builds, this can be used to get coverage for build scripts and
+            proc-macro while skipping coverage for the cross-compiled target which may not support
+            `instrument-coverage`.
+
     -v, --verbose
             Use verbose output
 

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -177,6 +177,25 @@ impl FromStr for Subcommand {
     }
 }
 
+/// Restriction to apply to the coverage target.
+#[derive(Debug, Copy, Clone)]
+pub(crate) enum TargetRestriction {
+    /// Activate coverage reporting only for the target triple
+    ///
+    /// Activate coverage reporting only for the target triple specified via `--target`.
+    /// This is important, if the project uses multiple targets via the cargo
+    /// bindeps feature, and not all targets can use `instrument-coverage`,
+    /// e.g. a microkernel, or an embedded binary.
+    ///
+    /// When this flag is used, coverage for proc-macro and build script will not be displayed.
+    TargetOnly,
+    /// Activate coverage reporting only for the host target triple.
+    ///
+    /// In cross-compilation builds, this can be used to get coverage for build scripts and proc-macro
+    /// while skipping coverage for the cross-compiled target which may not support `instrument-coverage`.
+    HostOnly,
+}
+
 /// Options only referred in "build"-related operations. (subcommands building/testing/running crates and show-env subcommand)
 #[derive(Debug, Default)]
 pub(crate) struct BuildOptions {
@@ -202,15 +221,8 @@ pub(crate) struct BuildOptions {
     /// must be set to Clang/LLVM compatible with the LLVM version used in rustc.
     // TODO: support specifying languages like: --include-ffi=c,  --include-ffi=c,c++
     pub(crate) include_ffi: bool,
-    /// Activate coverage reporting only for the target triple
-    ///
-    /// Activate coverage reporting only for the target triple specified via `--target`.
-    /// This is important, if the project uses multiple targets via the cargo
-    /// bindeps feature, and not all targets can use `instrument-coverage`,
-    /// e.g. a microkernel, or an embedded binary.
-    ///
-    /// When this flag is used, coverage for proc-macro and build script will not be displayed.
-    pub(crate) coverage_target_only: bool,
+    /// Possible restrictions to apply to the coverage target.
+    pub(crate) target_restriction: Option<TargetRestriction>,
     /// Unset cfg(coverage), which is enabled when code is built using cargo-llvm-cov.
     pub(crate) no_cfg_coverage: bool,
     /// Unset cfg(coverage_nightly), which is enabled when code is built using cargo-llvm-cov and nightly compiler.
@@ -900,6 +912,7 @@ impl Args {
         let mut release = false;
         let mut target = None;
         let mut coverage_target_only = false;
+        let mut coverage_host_only = false;
         let mut remap_path_prefix = false;
         let mut include_ffi = false;
         let mut verbose: usize = 0;
@@ -1062,6 +1075,7 @@ impl Args {
                 Long("cargo-profile") => parse_opt!(cargo_profile),
                 Long("target") => parse_opt!(target),
                 Long("coverage-target-only") => parse_flag!(coverage_target_only),
+                Long("coverage-host-only") => parse_flag!(coverage_host_only),
                 Long("remap-path-prefix") => parse_flag!(remap_path_prefix),
                 Long("include-ffi") => parse_flag!(include_ffi),
                 Long("no-clean") => parse_flag!(clean.no_clean),
@@ -1441,6 +1455,9 @@ impl Args {
         if coverage_target_only && target.is_none() {
             requires("--coverage-target-only", &["--target"])?;
         }
+        if coverage_target_only && coverage_host_only {
+            conflicts("--coverage-target-only", "--coverage-host-only")?;
+        }
 
         // conflicts
         if report.no_report && no_run {
@@ -1605,7 +1622,13 @@ impl Args {
                     branch,
                     mcdc,
                     include_ffi,
-                    coverage_target_only,
+                    target_restriction: if coverage_target_only {
+                        Some(TargetRestriction::TargetOnly)
+                    } else if coverage_host_only {
+                        Some(TargetRestriction::HostOnly)
+                    } else {
+                        None
+                    },
                     no_cfg_coverage,
                     no_cfg_coverage_nightly,
                     no_rustc_wrapper,

--- a/src/main.rs
+++ b/src/main.rs
@@ -267,25 +267,29 @@ fn set_env(cx: &Context, env: &mut dyn EnvTarget, IsNextest(is_nextest): IsNexte
             let mut rustflags =
                 cx.ws.config.rustflags(&cx.ws.target_for_config)?.unwrap_or_default();
             rustflags.flags.append(&mut additional_flags);
-            match (cx.args.build.coverage_target_only, &cx.args.target) {
-                (true, Some(coverage_target)) => {
-                    env.set(
-                        &format!("CARGO_TARGET_{}_RUSTFLAGS", target_u_upper(coverage_target)),
-                        &rustflags.encode_space_separated()?,
-                    )?;
-                    env.unset("RUSTFLAGS")?;
+
+            if let Some(restriction) = cx.args.build.target_restriction {
+                let coverage_triple = match restriction {
+                    cli::TargetRestriction::TargetOnly => cx.args.target.as_deref().expect(
+                        "`--target` must be specified when `--coverage-target-only` is used",
+                    ),
+                    cli::TargetRestriction::HostOnly => cx.ws.config.host_triple()?,
+                };
+                env.set(
+                    &format!("CARGO_TARGET_{}_RUSTFLAGS", target_u_upper(coverage_triple)),
+                    &rustflags.encode_space_separated()?,
+                )?;
+                env.unset("RUSTFLAGS")?;
+                env.unset("CARGO_ENCODED_RUSTFLAGS")?;
+            } else {
+                // First, try with RUSTFLAGS because `nextest` subcommand sometimes doesn't work well with encoded flags.
+                if let Ok(v) = rustflags.encode_space_separated() {
+                    env.set("RUSTFLAGS", &v)?;
                     env.unset("CARGO_ENCODED_RUSTFLAGS")?;
+                } else {
+                    env.set("CARGO_ENCODED_RUSTFLAGS", &rustflags.encode()?)?;
                 }
-                _ => {
-                    // First, try with RUSTFLAGS because `nextest` subcommand sometimes doesn't work well with encoded flags.
-                    if let Ok(v) = rustflags.encode_space_separated() {
-                        env.set("RUSTFLAGS", &v)?;
-                        env.unset("CARGO_ENCODED_RUSTFLAGS")?;
-                    } else {
-                        env.set("CARGO_ENCODED_RUSTFLAGS", &rustflags.encode()?)?;
-                    }
-                }
-            }
+            };
         }
     }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -289,7 +289,7 @@ fn set_env(cx: &Context, env: &mut dyn EnvTarget, IsNextest(is_nextest): IsNexte
                 } else {
                     env.set("CARGO_ENCODED_RUSTFLAGS", &rustflags.encode()?)?;
                 }
-            };
+            }
         }
     }
 

--- a/src/wrapper.rs
+++ b/src/wrapper.rs
@@ -44,15 +44,21 @@ pub(crate) fn set_env(cx: &Context, env: &mut dyn EnvTarget, rustflags: &Flags) 
 
     env.set(ENV_ENABLED, "1")?;
     env.set(ENV_RUSTFLAGS, &rustflags.encode()?)?;
-    match (cx.args.build.coverage_target_only, &cx.args.target) {
-        (true, Some(coverage_target)) => {
-            env.set(ENV_COVERAGE_TARGET, coverage_target)?;
-            env.set(ENV_HOST, cx.ws.config.host_triple()?)?;
-        }
-        _ => {
-            env.unset(ENV_COVERAGE_TARGET)?;
-            env.unset(ENV_HOST)?;
-        }
+    if let Some(restriction) = cx.args.build.target_restriction {
+        let host_triple = cx.ws.config.host_triple()?;
+        let coverage_target = match restriction {
+            cli::TargetRestriction::TargetOnly => cx
+                .args
+                .target
+                .as_deref()
+                .expect("`--target` must be specified when `--coverage-target-only` is used"),
+            cli::TargetRestriction::HostOnly => host_triple,
+        };
+        env.set(ENV_COVERAGE_TARGET, coverage_target)?;
+        env.set(ENV_HOST, host_triple)?;
+    } else {
+        env.unset(ENV_COVERAGE_TARGET)?;
+        env.unset(ENV_HOST)?;
     }
     let mut crates = String::new();
     for &id in &cx.ws.metadata.workspace_members {


### PR DESCRIPTION
Closes #489 

This implements the `--coverage-host-only` flag as suggested in that issue.

I have tested this branch against the PyO3 CI in https://github.com/PyO3/pyo3/pull/6007, and can confirm this flag is working as intended to allow me to verify build scripts & macro coverage when performing cross-compilation.