### PR TITLE
Support --remap-path-prefix for doctest

### DIFF
--- a/README.md
+++ b/README.md
@@ -331,8 +331,6 @@ OPTIONS:
         --remap-path-prefix
             Use --remap-path-prefix for workspace root
 
-            Note that this does not fully compatible with doctest.
-
         --include-ffi
             Include coverage of C/C++ code linked to Rust library/binary
 

--- a/docs/cargo-llvm-cov-report.txt
+++ b/docs/cargo-llvm-cov-report.txt
@@ -185,8 +185,6 @@ OPTIONS:
         --remap-path-prefix
             Use --remap-path-prefix for workspace root
 
-            Note that this does not fully compatible with doctest.
-
         --include-ffi
             Include coverage of C/C++ code linked to Rust library/binary
 

--- a/docs/cargo-llvm-cov-run.txt
+++ b/docs/cargo-llvm-cov-run.txt
@@ -225,8 +225,6 @@ OPTIONS:
         --remap-path-prefix
             Use --remap-path-prefix for workspace root
 
-            Note that this does not fully compatible with doctest.
-
         --include-ffi
             Include coverage of C/C++ code linked to Rust library/binary
 

--- a/docs/cargo-llvm-cov-show-env.txt
+++ b/docs/cargo-llvm-cov-show-env.txt
@@ -54,8 +54,6 @@ OPTIONS:
         --remap-path-prefix
             Use --remap-path-prefix for workspace root
 
-            Note that this does not fully compatible with doctest.
-
         --include-ffi
             Include coverage of C/C++ code linked to Rust library/binary
 

--- a/docs/cargo-llvm-cov-test.txt
+++ b/docs/cargo-llvm-cov-test.txt
@@ -281,8 +281,6 @@ OPTIONS:
         --remap-path-prefix
             Use --remap-path-prefix for workspace root
 
-            Note that this does not fully compatible with doctest.
-
         --include-ffi
             Include coverage of C/C++ code linked to Rust library/binary
 

--- a/docs/cargo-llvm-cov.txt
+++ b/docs/cargo-llvm-cov.txt
@@ -279,8 +279,6 @@ OPTIONS:
         --remap-path-prefix
             Use --remap-path-prefix for workspace root
 
-            Note that this does not fully compatible with doctest.
-
         --include-ffi
             Include coverage of C/C++ code linked to Rust library/binary
 

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -71,8 +71,6 @@ pub(crate) struct Args {
     pub(crate) verbose: u8,
 
     /// Use --remap-path-prefix for workspace root
-    ///
-    /// Note that this does not fully compatible with doctest.
     pub(crate) remap_path_prefix: bool,
 
     /// Show coverage of the specified dependency instead of the crates in the current workspace.

--- a/src/main.rs
+++ b/src/main.rs
@@ -300,6 +300,11 @@ fn set_env(cx: &Context, env: &mut dyn EnvTarget, IsNextest(is_nextest): IsNexte
             cx.ws.config.rustdocflags(&cx.ws.target_for_config)?.unwrap_or_default();
         {
             push_common_flags(cx, &mut rustdocflags);
+            // https://github.com/rust-lang/rust/pull/155307
+            if cx.args.remap_path_prefix {
+                rustdocflags.push("--remap-path-prefix");
+                rustdocflags.push(format!("{}/=", cx.ws.metadata.workspace_root));
+            }
             // flags needed for doctest coverage.
             // https://doc.rust-lang.org/nightly/rustc/instrument-coverage.html#including-doc-tests
             rustdocflags.push("-Z");


### PR DESCRIPTION
doctest --remap-path-prefix has been stabilized in https://github.com/rust-lang/rust/pull/155307.

TODO: needs test