### PR TITLE
Fix ShowEnvFormat::Fish formatting

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -356,7 +356,7 @@ jobs:
         if: matrix.os != 'windows-11-arm'
       - name: Test show-env --fish
         run: |
-          cargo llvm-cov show-env --sh > env.fish
+          cargo llvm-cov show-env --fish > env.fish
           cat -- env.fish
           source env.fish
           cargo llvm-cov clean --workspace

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -724,7 +724,7 @@ pub(crate) enum ShowEnvFormat {
     Cmd,
     /// Each key-value: `setenv {key} '{value}'`, where `{value}` is escaped using [`shell_escape::unix::escape`].
     Csh,
-    /// Each key-value: `set -gx {key}={value}`, where `{value}` is escaped using [`shell_escape::unix::escape`].
+    /// Each key-value: `set -gx {key} {value}`, where `{value}` is escaped using [`shell_escape::unix::escape`].
     Fish,
     /// Each key-value: `$env.{key} = {value}`, where `{value}` is escaped using [`shell_escape::unix::escape`].
     Nu,
@@ -764,7 +764,7 @@ impl ShowEnvFormat {
             }
             ShowEnvFormat::Fish => {
                 // TODO: https://fishshell.com/docs/current/language.html#quotes
-                writeln!(writer, "set -gx {key}={}", escape::sh(value.into()))
+                writeln!(writer, "set -gx {key} {}", escape::sh(value.into()))
             }
             ShowEnvFormat::Nu => {
                 // TODO: https://www.nushell.sh/lang-guide/chapters/strings_and_text.html#string-quoting


### PR DESCRIPTION
Separate the variable name and the value by a whitespace instead of '='.