### PR TITLE
Add --object flag to include arbitrary binaries in report (#367)

### DIFF
--- a/docs/cargo-llvm-cov-report.txt
+++ b/docs/cargo-llvm-cov-report.txt
@@ -86,6 +86,12 @@ OPTIONS:
         --ignore-filename-regex <PATTERN>
             Skip source code files with file paths that match the given regular expression
 
+        --object <PATH>
+            Add an object file (binary) to the coverage report.
+            Can be specified multiple times. Useful for including binaries that are
+            not part of the current workspace (e.g. examples or external test crates),
+            which would otherwise be filtered out by the automatic object-file detection.
+
         --show-instantiations
             Show instantiations in report
 

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -320,6 +320,13 @@ pub(crate) struct ReportOptions {
     pub(crate) failure_mode: Option<String>,
     /// Skip source code files with file paths that match the given regular expression.
     pub(crate) ignore_filename_regex: Option<String>,
+    /// Add an object file (binary) to the coverage report.
+    ///
+    /// Can be specified multiple times. This is useful for including binaries
+    /// that are not part of the current workspace (e.g. examples or external
+    /// test crates) in the report, which would otherwise be filtered out by
+    /// the automatic object-file detection.
+    pub(crate) object: Vec<String>,
     // For debugging (unstable)
     pub(crate) no_default_ignore_filename_regex: bool,
     /// Show instantiations in report
@@ -383,6 +390,7 @@ impl ReportOptions {
                 output_dir,
                 failure_mode,
                 ignore_filename_regex,
+                object,
                 no_default_ignore_filename_regex,
                 show_instantiations,
                 fail_under_functions,
@@ -409,6 +417,7 @@ impl ReportOptions {
                 ("--output-dir", output_dir.is_some()),
                 ("--failure-mode", failure_mode.is_some()),
                 ("--ignore-filename-regex", ignore_filename_regex.is_some()),
+                ("--object", !object.is_empty()),
                 ("--no-default-ignore-filename-regex", *no_default_ignore_filename_regex),
                 ("--show-instantiations", *show_instantiations),
                 ("--fail-under-functions", fail_under_functions.is_some()),
@@ -1101,6 +1110,27 @@ impl Args {
                 Long("output-dir") => parse_opt!(report.output_dir),
                 Long("failure-mode") => parse_opt!(report.failure_mode),
                 Long("ignore-filename-regex") => parse_opt!(report.ignore_filename_regex),
+                Long("object") => {
+                    // Ideally `parse_multi_opt!` would support dotted field access like
+                    // `report.object`, but modifying the macro risks regressions in its
+                    // existing callers (e.g. `--dep-coverage`), so the splitting logic is
+                    // inlined here instead.
+                    let val = parser.value()?;
+                    let mut val = val.to_str().unwrap();
+                    if val.starts_with('\'') && val.ends_with('\'')
+                        || val.starts_with('"') && val.ends_with('"')
+                    {
+                        val = &val[1..val.len() - 1];
+                    }
+                    let sep = if val.contains(',') { ',' } else { ' ' };
+                    report
+                        .object
+                        .extend(val.split(sep).filter(|s| !s.is_empty()).map(str::to_owned));
+                    #[allow(unused_assignments)]
+                    {
+                        after_subcommand = false;
+                    }
+                }
                 Long(
                     flag @ ("no-default-ignore-filename-regex"
                     | "disable-default-ignore-filename-regex"),

--- a/src/report.rs
+++ b/src/report.rs
@@ -547,6 +547,13 @@ fn object_files(cx: &Context) -> Result<Vec<OsString>> {
     };
     collect_ui_test_target_dir(ui_test_target_dir)?;
 
+    // Explicitly specified object files (e.g. binaries of non-workspace crates
+    // like examples or external test crates). These bypass the workspace-member
+    // filename whitelist used by the automatic detection above.
+    for obj in &cx.args.report.object {
+        files.push(Utf8PathBuf::from(obj).into_os_string());
+    }
+
     // This sort is necessary to make the result of `llvm-cov show` match between macOS and Linux.
     files.sort_unstable();
 


### PR DESCRIPTION
The automatic object-file detection only collects binaries whose names match the current workspace members, so coverage from non-workspace binaries (e.g. examples or external test crates) is dropped even when their profraw data was recorded. Add a repeatable --object <PATH> flag to explicitly include such binaries in the report.

Fixes #367