### PR TITLE
feat(report): add `--include-examples` flag

### DIFF
--- a/docs/cargo-llvm-cov-report.txt
+++ b/docs/cargo-llvm-cov-report.txt
@@ -89,6 +89,11 @@ OPTIONS:
         --show-instantiations
             Show instantiations in report
 
+        --include-tests-examples-benches
+            Include source files under `tests`/`examples`/`benches` directories in
+            the report, which are excluded by default. Test entry files
+            (`tests.rs`/`*_tests.rs`) remain excluded.
+
         --fail-under-functions <MIN>
             Exit with a status of 1 if the total function coverage is less than MIN percent
 

--- a/docs/cargo-llvm-cov-report.txt
+++ b/docs/cargo-llvm-cov-report.txt
@@ -89,9 +89,9 @@ OPTIONS:
         --show-instantiations
             Show instantiations in report
 
-        --include-tests-examples-benches
-            Include source files under `tests`/`examples`/`benches` directories in
-            the report, which are excluded by default. Test entry files
+        --include-examples
+            Include source files under the `examples` directory in the report,
+            which are excluded by default. Test entry files
             (`tests.rs`/`*_tests.rs`) remain excluded.
 
         --fail-under-functions <MIN>

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -324,6 +324,12 @@ pub(crate) struct ReportOptions {
     pub(crate) no_default_ignore_filename_regex: bool,
     /// Show instantiations in report
     pub(crate) show_instantiations: bool,
+    /// Include test/example/bench source files in the report.
+    ///
+    /// By default, files under `tests`/`examples`/`benches` directories are
+    /// excluded from the report; this flag disables that exclusion. Test entry
+    /// files (`tests.rs`/`*_tests.rs`) are always excluded.
+    pub(crate) include_tests_examples_benches: bool,
     /// Exit with a status of 1 if the total function coverage is less than MIN percent.
     pub(crate) fail_under_functions: Option<f64>,
     /// Exit with a status of 1 if the total line coverage is less than MIN percent.
@@ -385,6 +391,7 @@ impl ReportOptions {
                 ignore_filename_regex,
                 no_default_ignore_filename_regex,
                 show_instantiations,
+                include_tests_examples_benches,
                 fail_under_functions,
                 fail_under_lines,
                 fail_under_file_lines,
@@ -411,6 +418,7 @@ impl ReportOptions {
                 ("--ignore-filename-regex", ignore_filename_regex.is_some()),
                 ("--no-default-ignore-filename-regex", *no_default_ignore_filename_regex),
                 ("--show-instantiations", *show_instantiations),
+                ("--include-tests-examples-benches", *include_tests_examples_benches),
                 ("--fail-under-functions", fail_under_functions.is_some()),
                 ("--fail-under-lines", fail_under_lines.is_some()),
                 ("--fail-under-file-lines", fail_under_file_lines.is_some()),
@@ -1111,6 +1119,9 @@ impl Args {
                     parse_flag!(report.no_default_ignore_filename_regex);
                 }
                 Long("show-instantiations") => parse_flag!(report.show_instantiations),
+                Long("include-tests-examples-benches") => {
+                    parse_flag!(report.include_tests_examples_benches);
+                }
                 Long("hide-instantiations") => {
                     // The following warning is a hint, so it should not be promoted to an error.
                     let _guard = term::warn::ignore();

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -324,12 +324,13 @@ pub(crate) struct ReportOptions {
     pub(crate) no_default_ignore_filename_regex: bool,
     /// Show instantiations in report
     pub(crate) show_instantiations: bool,
-    /// Include test/example/bench source files in the report.
+    /// Include source files in the `examples` directory in the report.
     ///
     /// By default, files under `tests`/`examples`/`benches` directories are
-    /// excluded from the report; this flag disables that exclusion. Test entry
-    /// files (`tests.rs`/`*_tests.rs`) are always excluded.
-    pub(crate) include_tests_examples_benches: bool,
+    /// excluded from the report; this flag lifts the exclusion only for the
+    /// `examples` directory. Test entry files (`tests.rs`/`*_tests.rs`) are
+    /// always excluded.
+    pub(crate) include_examples: bool,
     /// Exit with a status of 1 if the total function coverage is less than MIN percent.
     pub(crate) fail_under_functions: Option<f64>,
     /// Exit with a status of 1 if the total line coverage is less than MIN percent.
@@ -391,7 +392,7 @@ impl ReportOptions {
                 ignore_filename_regex,
                 no_default_ignore_filename_regex,
                 show_instantiations,
-                include_tests_examples_benches,
+                include_examples,
                 fail_under_functions,
                 fail_under_lines,
                 fail_under_file_lines,
@@ -418,7 +419,7 @@ impl ReportOptions {
                 ("--ignore-filename-regex", ignore_filename_regex.is_some()),
                 ("--no-default-ignore-filename-regex", *no_default_ignore_filename_regex),
                 ("--show-instantiations", *show_instantiations),
-                ("--include-tests-examples-benches", *include_tests_examples_benches),
+                ("--include-examples", *include_examples),
                 ("--fail-under-functions", fail_under_functions.is_some()),
                 ("--fail-under-lines", fail_under_lines.is_some()),
                 ("--fail-under-file-lines", fail_under_file_lines.is_some()),
@@ -1119,9 +1120,7 @@ impl Args {
                     parse_flag!(report.no_default_ignore_filename_regex);
                 }
                 Long("show-instantiations") => parse_flag!(report.show_instantiations),
-                Long("include-tests-examples-benches") => {
-                    parse_flag!(report.include_tests_examples_benches);
-                }
+                Long("include-examples") => parse_flag!(report.include_examples),
                 Long("hide-instantiations") => {
                     // The following warning is a hint, so it should not be promoted to an error.
                     let _guard = term::warn::ignore();

--- a/src/report.rs
+++ b/src/report.rs
@@ -7,6 +7,7 @@
 use std::{
     collections::{BTreeSet, HashMap},
     ffi::{OsStr, OsString},
+    fmt::Write as _,
     io::{self, BufRead as _, BufWriter, Read as _, Write as _},
     path::Path,
     time::SystemTime,
@@ -914,40 +915,35 @@ fn ignore_filename_regex(cx: &Context, object_files: &[OsString]) -> Result<Opti
         if cx.args.dep_coverage.is_empty() {
             // TODO: Should we use the actual target path instead of using `tests|examples|benches`?
             //       We may have a directory like tests/support, so maybe we need both?
-            //       `--include-tests-examples-benches` currently lifts the directory
-            //       exclusion wholesale as an opt-in workaround.
-            let exclude_test_dirs = !cx.args.report.include_tests_examples_benches;
-            if cx.args.remap_path_prefix {
-                if exclude_test_dirs {
-                    out.push(format!(
-                        r"(^|{SEPARATOR})(rustc{SEPARATOR}([0-9a-f]+|[0-9]+\.[0-9]+\.[0-9]+)|tests|examples|benches){SEPARATOR}"
-                    ));
-                } else {
-                    out.push(format!(
-                        r"(^|{SEPARATOR})rustc{SEPARATOR}([0-9a-f]+|[0-9]+\.[0-9]+\.[0-9]+){SEPARATOR}"
-                    ));
-                }
-                // Test entry files (e.g. `tests.rs`, `foo_tests.rs`) are always
-                // excluded, regardless of `--include-tests-examples-benches`.
-                out.push(format!(r"{SEPARATOR}(tests\.rs|[0-9a-zA-Z_-]+[_-]tests\.rs)$"));
+            // `--include-examples` only lifts the exclusion for the `examples` directory;
+            // `tests`/`benches` directories are still excluded.
+            let dirs = if cx.args.report.include_examples {
+                "tests|benches"
             } else {
-                if exclude_test_dirs {
-                    out.push(format!(
-                        r"{SEPARATOR}rustc{SEPARATOR}([0-9a-f]+|[0-9]+\.[0-9]+\.[0-9]+){SEPARATOR}|^{workspace_root}({SEPARATOR}.*)?{SEPARATOR}(tests|examples|benches){SEPARATOR}",
-                        workspace_root = regex::escape(cx.ws.metadata.workspace_root.as_str())
-                    ));
-                } else {
-                    out.push(format!(
-                        r"{SEPARATOR}rustc{SEPARATOR}([0-9a-f]+|[0-9]+\.[0-9]+\.[0-9]+){SEPARATOR}"
-                    ));
-                }
-                // Test entry files (e.g. `tests.rs`, `foo_tests.rs`) are always
-                // excluded, regardless of `--include-tests-examples-benches`.
-                out.push(format!(
-                    r"^{workspace_root}({SEPARATOR}.*)?{SEPARATOR}(tests\.rs|[0-9a-zA-Z_-]+[_-]tests\.rs)$",
+                "tests|examples|benches"
+            };
+            let mut ignore_re = String::new();
+            if cx.args.remap_path_prefix {
+                let _ = write!(
+                    ignore_re,
+                    r"(^|{SEPARATOR})(rustc{SEPARATOR}([0-9a-f]+|[0-9]+\.[0-9]+\.[0-9]+)|{dirs}){SEPARATOR}"
+                );
+                // Test entry files (e.g. `tests.rs`, `foo_tests.rs`) are always excluded.
+                let _ = write!(ignore_re, r"|{SEPARATOR}(tests\.rs|[0-9a-zA-Z_-]+[_-]tests\.rs)$");
+            } else {
+                let _ = write!(
+                    ignore_re,
+                    r"{SEPARATOR}rustc{SEPARATOR}([0-9a-f]+|[0-9]+\.[0-9]+\.[0-9]+){SEPARATOR}|^{workspace_root}({SEPARATOR}.*)?{SEPARATOR}({dirs}){SEPARATOR}",
                     workspace_root = regex::escape(cx.ws.metadata.workspace_root.as_str())
-                ));
+                );
+                // Test entry files (e.g. `tests.rs`, `foo_tests.rs`) are always excluded.
+                let _ = write!(
+                    ignore_re,
+                    r"|^{workspace_root}({SEPARATOR}.*)?{SEPARATOR}(tests\.rs|[0-9a-zA-Z_-]+[_-]tests\.rs)$",
+                    workspace_root = regex::escape(cx.ws.metadata.workspace_root.as_str())
+                );
             }
+            out.push(ignore_re);
             out.push_abs_path(&cx.ws.target_dir);
             if let Some(build_dir) = &cx.ws.build_dir {
                 if *build_dir != cx.ws.target_dir {

--- a/src/report.rs
+++ b/src/report.rs
@@ -914,13 +914,37 @@ fn ignore_filename_regex(cx: &Context, object_files: &[OsString]) -> Result<Opti
         if cx.args.dep_coverage.is_empty() {
             // TODO: Should we use the actual target path instead of using `tests|examples|benches`?
             //       We may have a directory like tests/support, so maybe we need both?
+            //       `--include-tests-examples-benches` currently lifts the directory
+            //       exclusion wholesale as an opt-in workaround.
+            let exclude_test_dirs = !cx.args.report.include_tests_examples_benches;
             if cx.args.remap_path_prefix {
-                out.push(format!(
-                    r"(^|{SEPARATOR})(rustc{SEPARATOR}([0-9a-f]+|[0-9]+\.[0-9]+\.[0-9]+)|tests|examples|benches){SEPARATOR}|{SEPARATOR}(tests\.rs|[0-9a-zA-Z_-]+[_-]tests\.rs)$"
-                ));
+                if exclude_test_dirs {
+                    out.push(format!(
+                        r"(^|{SEPARATOR})(rustc{SEPARATOR}([0-9a-f]+|[0-9]+\.[0-9]+\.[0-9]+)|tests|examples|benches){SEPARATOR}"
+                    ));
+                } else {
+                    out.push(format!(
+                        r"(^|{SEPARATOR})rustc{SEPARATOR}([0-9a-f]+|[0-9]+\.[0-9]+\.[0-9]+){SEPARATOR}"
+                    ));
+                }
+                // Test entry files (e.g. `tests.rs`, `foo_tests.rs`) are always
+                // excluded, regardless of `--include-tests-examples-benches`.
+                out.push(format!(r"{SEPARATOR}(tests\.rs|[0-9a-zA-Z_-]+[_-]tests\.rs)$"));
             } else {
+                if exclude_test_dirs {
+                    out.push(format!(
+                        r"{SEPARATOR}rustc{SEPARATOR}([0-9a-f]+|[0-9]+\.[0-9]+\.[0-9]+){SEPARATOR}|^{workspace_root}({SEPARATOR}.*)?{SEPARATOR}(tests|examples|benches){SEPARATOR}",
+                        workspace_root = regex::escape(cx.ws.metadata.workspace_root.as_str())
+                    ));
+                } else {
+                    out.push(format!(
+                        r"{SEPARATOR}rustc{SEPARATOR}([0-9a-f]+|[0-9]+\.[0-9]+\.[0-9]+){SEPARATOR}"
+                    ));
+                }
+                // Test entry files (e.g. `tests.rs`, `foo_tests.rs`) are always
+                // excluded, regardless of `--include-tests-examples-benches`.
                 out.push(format!(
-                    r"{SEPARATOR}rustc{SEPARATOR}([0-9a-f]+|[0-9]+\.[0-9]+\.[0-9]+){SEPARATOR}|^{workspace_root}({SEPARATOR}.*)?{SEPARATOR}(tests|examples|benches){SEPARATOR}|^{workspace_root}({SEPARATOR}.*)?{SEPARATOR}(tests\.rs|[0-9a-zA-Z_-]+[_-]tests\.rs)$",
+                    r"^{workspace_root}({SEPARATOR}.*)?{SEPARATOR}(tests\.rs|[0-9a-zA-Z_-]+[_-]tests\.rs)$",
                     workspace_root = regex::escape(cx.ws.metadata.workspace_root.as_str())
                 ));
             }


### PR DESCRIPTION
The default --ignore-filename-regex unconditionally excludes files under tests/examples/benches directories and tests.rs/*_tests.rs files from reports, even when --examples/--tests are passed. Add an opt-in flag to lift that exclusion for users who want to measure test/example coverage.

Fixes #503