### PR TITLE
docs: add inspect.software health badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,6 +3,7 @@
 [![crates.io](https://img.shields.io/crates/v/cargo-llvm-cov?style=flat-square&logo=rust)](https://crates.io/crates/cargo-llvm-cov)
 [![license](https://img.shields.io/badge/license-Apache--2.0_OR_MIT-blue?style=flat-square)](#license)
 [![github actions](https://img.shields.io/github/actions/workflow/status/taiki-e/cargo-llvm-cov/ci.yml?branch=main&style=flat-square&logo=github)](https://github.com/taiki-e/cargo-llvm-cov/actions)
+[![inspect.software](https://raw.githubusercontent.com/inspect-software/badges/main/v1/t/taiki-e/cargo-llvm-cov.svg)](https://inspect.software/software/taiki-e/cargo-llvm-cov)
 
 Cargo subcommand to easily use LLVM source-based code coverage.
 


### PR DESCRIPTION
This PR adds the [inspect.software](https://inspect.software) health badge to the README.

**Why this PR?**
Your project ranks in the upper rating bands of our open-source health index (which measures maintainability, responsiveness, and security). This badge makes that standing objectively visible to your users. Our index is a free public good, and scores cannot be bought.

**Technical details:**
- **No tracking:** Static SVG served via GitHub's CDN. No JavaScript, no third-party tracking.
- **No maintenance:** The badge updates automatically after every inspection.
- **Transparent:** Links directly to [your full report](https://inspect.software/software/taiki-e/cargo-llvm-cov), based on our open [methodology](https://inspect.software/methodology).

If you prefer to keep your README minimal, feel free to close this PR without replying. Your report will remain publicly available and up-to-date either way.
