### PR TITLE
Add --coverage-watermark option to set html report color thresholds

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,8 @@ Note: In this file, do not use the hard wrap in the middle of a sentence for com
 
 ## [Unreleased]
 
+- Add `--coverage-watermark` option to set the coverage color thresholds of the html report.
+
 ## [0.9.0] - 2026-08-16
 
 - Change `--show-missing-lines` reporting to aggregate consecutive line numbers. ([#497](https://github.com/taiki-e/cargo-llvm-cov/pull/497), thanks @saroad2)

--- a/README.md
+++ b/README.md
@@ -142,6 +142,13 @@ OPTIONS:
         --show-instantiations
             Show instantiations in report
 
+        --coverage-watermark <HIGH,LOW>
+            Set the coverage watermarks (percentages) used for the colors of the html report
+
+            Regions with coverage of at least HIGH percent are shown in green, at least LOW
+            percent in yellow, and the rest in red. This flag can only be used together with
+            --html or --open.
+
         --no-cfg-coverage
             Unset cfg(coverage), which is enabled when code is built using cargo-llvm-cov
 

--- a/docs/cargo-llvm-cov-report.txt
+++ b/docs/cargo-llvm-cov-report.txt
@@ -89,6 +89,13 @@ OPTIONS:
         --show-instantiations
             Show instantiations in report
 
+        --coverage-watermark <HIGH,LOW>
+            Set the coverage watermarks (percentages) used for the colors of the html report
+
+            Regions with coverage of at least HIGH percent are shown in green, at least LOW
+            percent in yellow, and the rest in red. This flag can only be used together with
+            --html or --open.
+
         --fail-under-functions <MIN>
             Exit with a status of 1 if the total function coverage is less than MIN percent
 

--- a/docs/cargo-llvm-cov-run.txt
+++ b/docs/cargo-llvm-cov-run.txt
@@ -90,6 +90,13 @@ OPTIONS:
         --show-instantiations
             Show instantiations in report
 
+        --coverage-watermark <HIGH,LOW>
+            Set the coverage watermarks (percentages) used for the colors of the html report
+
+            Regions with coverage of at least HIGH percent are shown in green, at least LOW
+            percent in yellow, and the rest in red. This flag can only be used together with
+            --html or --open.
+
         --no-cfg-coverage
             Unset cfg(coverage), which is enabled when code is built using cargo-llvm-cov
 

--- a/docs/cargo-llvm-cov-test.txt
+++ b/docs/cargo-llvm-cov-test.txt
@@ -95,6 +95,13 @@ OPTIONS:
         --show-instantiations
             Show instantiations in report
 
+        --coverage-watermark <HIGH,LOW>
+            Set the coverage watermarks (percentages) used for the colors of the html report
+
+            Regions with coverage of at least HIGH percent are shown in green, at least LOW
+            percent in yellow, and the rest in red. This flag can only be used together with
+            --html or --open.
+
         --no-cfg-coverage
             Unset cfg(coverage), which is enabled when code is built using cargo-llvm-cov
 

--- a/docs/cargo-llvm-cov.txt
+++ b/docs/cargo-llvm-cov.txt
@@ -90,6 +90,13 @@ OPTIONS:
         --show-instantiations
             Show instantiations in report
 
+        --coverage-watermark <HIGH,LOW>
+            Set the coverage watermarks (percentages) used for the colors of the html report
+
+            Regions with coverage of at least HIGH percent are shown in green, at least LOW
+            percent in yellow, and the rest in red. This flag can only be used together with
+            --html or --open.
+
         --no-cfg-coverage
             Unset cfg(coverage), which is enabled when code is built using cargo-llvm-cov
 

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -324,6 +324,8 @@ pub(crate) struct ReportOptions {
     pub(crate) no_default_ignore_filename_regex: bool,
     /// Show instantiations in report
     pub(crate) show_instantiations: bool,
+    /// Set the coverage watermarks (percentages, formatted as `HIGH,LOW`) for the html report.
+    pub(crate) coverage_watermark: Option<String>,
     /// Exit with a status of 1 if the total function coverage is less than MIN percent.
     pub(crate) fail_under_functions: Option<f64>,
     /// Exit with a status of 1 if the total line coverage is less than MIN percent.
@@ -385,6 +387,7 @@ impl ReportOptions {
                 ignore_filename_regex,
                 no_default_ignore_filename_regex,
                 show_instantiations,
+                coverage_watermark,
                 fail_under_functions,
                 fail_under_lines,
                 fail_under_file_lines,
@@ -411,6 +414,7 @@ impl ReportOptions {
                 ("--ignore-filename-regex", ignore_filename_regex.is_some()),
                 ("--no-default-ignore-filename-regex", *no_default_ignore_filename_regex),
                 ("--show-instantiations", *show_instantiations),
+                ("--coverage-watermark", coverage_watermark.is_some()),
                 ("--fail-under-functions", fail_under_functions.is_some()),
                 ("--fail-under-lines", fail_under_lines.is_some()),
                 ("--fail-under-file-lines", fail_under_file_lines.is_some()),
@@ -1111,6 +1115,7 @@ impl Args {
                     parse_flag!(report.no_default_ignore_filename_regex);
                 }
                 Long("show-instantiations") => parse_flag!(report.show_instantiations),
+                Long("coverage-watermark") => parse_opt!(report.coverage_watermark),
                 Long("hide-instantiations") => {
                     // The following warning is a hint, so it should not be promoted to an error.
                     let _guard = term::warn::ignore();

--- a/src/report.rs
+++ b/src/report.rs
@@ -727,6 +727,12 @@ impl ReportFormat {
                     // -show-mcdc requires LLVM 18+
                     cmd.arg("-show-mcdc");
                 }
+                // -coverage-watermark only affects the coloring of the html report.
+                if self == Self::Html {
+                    if let Some(coverage_watermark) = &cx.args.report.coverage_watermark {
+                        cmd.arg(format!("-coverage-watermark={coverage_watermark}"));
+                    }
+                }
                 let mut demangler = OsString::from("-Xdemangler=");
                 demangler.push(&cx.current_exe);
                 cmd.arg(demangler);

--- a/tests/test.rs
+++ b/tests/test.rs
@@ -112,6 +112,21 @@ fn instantiations() {
     run("instantiations", "instantiations", &[], &[]);
 }
 
+// `--coverage-watermark` only changes the colors in the html report, so there is nothing stable
+// to snapshot. Just check that the html report is still generated when the flag is passed.
+#[rustversion::attr(before(1.88), ignore)]
+#[test]
+fn coverage_watermark() {
+    let workspace_root = test_project("real1");
+    let output_dir = tempfile::tempdir().unwrap();
+    cargo_llvm_cov("test")
+        .args(["--html", "--coverage-watermark", "70,40", "--output-dir"])
+        .arg(output_dir.path())
+        .current_dir(workspace_root.path())
+        .assert_success();
+    assert!(output_dir.path().join("html").join("index.html").exists());
+}
+
 // 1.88 fixed bug in report generation, so the latest report is not the same as the old report.
 #[rustversion::attr(before(1.88), ignore)]
 #[test]


### PR DESCRIPTION
Closes #488.

llvm-cov's html output has a `-coverage-watermark=<high>,<low>` option that controls the thresholds where the coverage colors switch between green, yellow and red, but there was no way to set it from cargo-llvm-cov short of going through `LLVM_COV_FLAGS`.

This adds a `--coverage-watermark <HIGH,LOW>` report option that gets forwarded to `llvm-cov show` for the html report. It only applies to `--html`/`--open`, and when the flag is not passed nothing changes, so existing behavior is untouched.

I verified locally that the value ends up on the llvm-cov invocation and that the html report is still generated. The added test just checks that the report is produced with the flag set, since the only thing the flag changes is the html coloring and there is nothing stable to snapshot.